### PR TITLE
depend on conf-pkg-config, which is executed by the cross-compilation runes

### DIFF
--- a/mirage-crypto.opam
+++ b/mirage-crypto.opam
@@ -13,6 +13,7 @@ build: [ ["dune" "subst"] {pinned}
          ["dune" "runtest" "-p" name "-j" jobs] {with-test} ]
 
 depends: [
+  "conf-pkg-config" {build}
   "ocaml" {>= "4.07.0"}
   "dune" {>= "1.7"}
   "dune-configurator" {>= "2.0.0"}
@@ -22,10 +23,11 @@ depends: [
   "ocplib-endian"
   "sexplib"
   "ppx_sexp_conv"
-  ("mirage-no-xen" | ("mirage-xen" & "mirage-xen-posix"))
-  ("mirage-no-solo5" | ("mirage-solo5" & "ocaml-freestanding"))
 ]
-
+depopts: [
+  "mirage-xen-posix"
+  "ocaml-freestanding"
+]
 conflicts: [
   "mirage-xen" {< "3.1.0"}
   "ocaml-freestanding" {< "0.4.1"}


### PR DESCRIPTION
also mirage-xen-posix and ocaml-freestanding are depopts (and mirage-xen/mirage-solo5 are not needed at all anymore)