### PR TITLE
no sexplib in main mirage-crypto anymore

### DIFF
--- a/mirage-crypto.opam
+++ b/mirage-crypto.opam
@@ -21,8 +21,6 @@ depends: [
   "ounit" {with-test}
   "cstruct" {>="3.2.0"}
   "ocplib-endian"
-  "sexplib"
-  "ppx_sexp_conv"
 ]
 depopts: [
   "mirage-xen-posix"

--- a/rng/unix/mirage_crypto_rng_unix.ml
+++ b/rng/unix/mirage_crypto_rng_unix.ml
@@ -8,7 +8,7 @@ module Getrandom = struct
 
   let block = 256
 
-  open Bigarray
+  open Stdlib.Bigarray
   type buffer = (char, int8_unsigned_elt, c_layout) Array1.t
   external getrandom : buffer -> int -> unit = "mc_getrandom" [@@noalloc]
 

--- a/src/dune
+++ b/src/dune
@@ -1,8 +1,7 @@
 (library
   (name mirage_crypto)
   (public_name mirage-crypto)
-  (libraries cstruct ocplib-endian sexplib)
-  (preprocess (pps ppx_sexp_conv))
+  (libraries cstruct ocplib-endian)
   (private_modules base64 ccm cipher_block cipher_stream hash native uncommon)
   (c_names misc
            md5 sha1 sha256 sha512 hash_stubs

--- a/src/hash.ml
+++ b/src/hash.ml
@@ -118,7 +118,6 @@ module SHA512 = Hash_of (Native.SHA512) ( struct
 end )
 
 type hash = [ `MD5 | `SHA1 | `SHA224 | `SHA256 | `SHA384 | `SHA512 ]
-[@@deriving sexp]
 
 let hashes = [ `MD5; `SHA1; `SHA224; `SHA256; `SHA384; `SHA512 ]
 

--- a/src/mirage_crypto.mli
+++ b/src/mirage_crypto.mli
@@ -14,12 +14,6 @@
     public key cryptography.
 *)
 
-(*
- * Doc note: Sexplib conversions are noted explicitly instead of using
- * `[@@deriving sexp]` because the syntax extension interacts badly with
- * ocamldoc.
- *)
-
 (** {1 Utilities} *)
 
 (** Base64 conversion.
@@ -201,9 +195,7 @@ module Hash : sig
   (** {1 Codes-based interface} *)
 
   type hash = [ `MD5 | `SHA1 | `SHA224 | `SHA256 | `SHA384 | `SHA512 ]
-  (** Algorithm codes.
-
-      {e [Sexplib] convertible}. *)
+  (** Algorithm codes. *)
 
   val hashes : hash list
 
@@ -218,12 +210,6 @@ module Hash : sig
   val mac         : [< hash ] -> key:Cstruct.t -> Cstruct.t -> digest
   val maci        : [< hash ] -> key:Cstruct.t -> Cstruct.t iter -> digest
   val digest_size : [< hash ] -> int
-
-  (**/**)
-  val hash_of_sexp : Sexplib.Sexp.t -> hash
-  val sexp_of_hash : hash -> Sexplib.Sexp.t
-  (**/**)
-
 end
 
 

--- a/src/native.ml
+++ b/src/native.ml
@@ -1,5 +1,5 @@
 
-open Bigarray
+open Stdlib.Bigarray
 
 let buffer = Array1.create char c_layout
 


### PR DESCRIPTION
only `Hash.hash` used sexplib (used by tls), we can just move the code to tls instead and get a sexplib-free mirage-crypto.