### PR TITLE
travis: on ubuntu use mirage-xen-posix and zarith-xen as depopts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,6 @@ matrix:
   - os: osx
     env: OCAML_VERSION=4.08
   - dist: xenial
-    env: OCAML_VERSION=4.08
+    env: OCAML_VERSION=4.08 DEPOPTS="zarith-xen mirage-xen-posix"
 notifications:
   email: false


### PR DESCRIPTION
so we actually test that (please note that the cirrus runners install zarith-freestanding (and thus ocaml-freestanding) as optional dependencies --> the freestanding sublibraries are already under CI :)