### PR TITLE
entropy adjustments: check return value of rdrand/rdseed (and retry up to 10 times), cope with AMD ryzen 3000 bug

### DIFF
--- a/src/native/entropy_cpu_stubs.c
+++ b/src/native/entropy_cpu_stubs.c
@@ -112,7 +112,7 @@ CAMLprim value caml_cpu_checked_random (value __unused(unit)) {
   int i = RETRIES;
   switch (__cpu_rng) {
   case RNG_RDSEED:
-    do { ok = _rdseed_step (&r); } while ( !(ok | !--i) );
+    do { ok = _rdseed_step (&r); _mm_pause (); } while ( !(ok | !--i) );
     break;
   case RNG_RDRAND:
     do { ok = _rdrand_step (&r); } while ( !(ok | !--i) );


### PR DESCRIPTION
check rdrand and rdseed return values (CR=1), as recommended by Intel (https://software.intel.com/en-us/articles/intel-digital-random-number-generator-drng-software-implementation-guide)

detect bad rdrand on ryzen 3000 (which returns all-ones) and disable there