### PR TITLE
pk: make private and public key private structures

### DIFF
--- a/mirage-crypto-pk.opam
+++ b/mirage-crypto-pk.opam
@@ -27,6 +27,7 @@ depends: [
   "ppx_sexp_conv"
   "zarith"
   "eqaf" {>= "0.5"}
+  "rresult" {>= "0.6.0"}
   ("mirage-no-xen" | "zarith-xen")
   ("mirage-no-solo5" | "zarith-freestanding")
 ]

--- a/pk/common.ml
+++ b/pk/common.ml
@@ -1,5 +1,7 @@
 let rec until p f = let r = f () in if p r then r else until p f
 
+let guard p err = if p then Ok () else Error err
+
 (* The Sexplib hack... *)
 module Z_sexp = struct
   type t = Z.t

--- a/pk/dsa.ml
+++ b/pk/dsa.ml
@@ -1,14 +1,48 @@
 open Mirage_crypto.Uncommon
 open Sexplib.Conv
+open Rresult
 
 open Common
 
 type pub = { p : Z_sexp.t ; q : Z_sexp.t ; gg : Z_sexp.t ; y : Z_sexp.t }
 [@@deriving sexp]
 
+let pub ?(fips = false) ~p ~q ~gg ~y =
+  guard Z.(one < gg && gg < p) (`Msg "bad generator") >>= fun () ->
+  guard (Z_extra.pseudoprime q) (`Msg "q is not prime") >>= fun () ->
+  guard (Z.is_odd p && Z_extra.pseudoprime p) (`Msg "p is not prime") >>= fun () ->
+  guard Z.(zero < y && y < p) (`Msg "y not in 0..p-1") >>= fun () ->
+  guard (q < p) (`Msg "q is not smaller than p") >>= fun () ->
+  guard Z.(zero = (pred p) mod q) (`Msg "p - 1 mod q <> 0") >>= fun () ->
+  (if fips then
+     match Z.numbits p, Z.numbits q with
+     | 1024, 160 | 2048, 224 | 2048, 256 | 3072, 256 -> Ok ()
+     | _ -> Error (`Msg "bit length of p or q not FIPS specified")
+   else
+     Ok ()) >>= fun () ->
+  Ok { p ; q ; gg ; y }
+
+let pub_of_sexp s =
+  let p = pub_of_sexp s in
+  match pub ?fips:None ~p:p.p ~q:p.q ~gg:p.gg ~y:p.y with
+  | Ok p -> p
+  | Error (`Msg m) -> invalid_arg "bad public %s" m
+
 type priv =
   { p : Z_sexp.t ; q : Z_sexp.t ; gg : Z_sexp.t ; x : Z_sexp.t ; y : Z_sexp.t }
 [@@deriving sexp]
+
+let priv ?fips ~p ~q ~gg ~x ~y =
+  pub ?fips ~p ~q ~gg ~y >>= fun _ ->
+  guard Z.(zero < x && x < q) (`Msg "x not in 1..q-1") >>= fun () ->
+  guard Z.(y = powm gg x p) (`Msg "y <> g ^ x mod p") >>= fun () ->
+  Ok { p ; q ; gg ; x ; y }
+
+let priv_of_sexp s =
+  let p = priv_of_sexp s in
+  match priv ?fips:None ~p:p.p ~q:p.q ~gg:p.gg ~x:p.x ~y:p.y with
+  | Ok p -> p
+  | Error (`Msg m) -> invalid_arg "bad private %s" m
 
 let pub_of_priv { p; q; gg; y; _ } = { p; q; gg; y }
 
@@ -43,18 +77,22 @@ let params ?g size =
     let q_q  = Z.(q * two) in
     until Z_extra.pseudoprime @@ fun () ->
       let x = Z_extra.gen_bits ?g ~msb:1 l in
-      Z.(x - (x mod q_q) + one) in
+      Z.(x - (x mod q_q) + one)
+  in
   let gg =
     let e = Z.(pred p / q) in
     until ((<>) Z.one) @@ fun () ->
       let h = Z_extra.gen_r ?g two Z.(pred p) in
-      Z.(powm h e p) in
+      Z.(powm h e p)
+  in
+  (* all checks above are already satisfied *)
   (p, q, gg)
 
 let generate ?g size =
   let (p, q, gg) = params ?g size in
   let x = Z_extra.gen_r ?g Z.one q in
   let y = Z.(powm gg x p) in
+  (* checks are satisfied due to construction *)
   { p; q; gg; x; y }
 
 

--- a/pk/dune
+++ b/pk/dune
@@ -1,6 +1,6 @@
 (library
   (name mirage_crypto_pk)
   (public_name mirage-crypto-pk)
-  (libraries cstruct zarith mirage-crypto mirage-crypto-rng sexplib eqaf.cstruct)
+  (libraries cstruct zarith mirage-crypto mirage-crypto-rng sexplib eqaf.cstruct rresult)
   (preprocess (pps ppx_sexp_conv))
   (private_modules common dh dsa rsa z_extra))

--- a/pk/mirage_crypto_pk.mli
+++ b/pk/mirage_crypto_pk.mli
@@ -348,16 +348,19 @@ module Dsa : sig
       [n] is ridiculously small. *)
 
   val sign : ?mask:mask -> ?k:Z.t -> key:priv -> Cstruct.t -> Cstruct.t * Cstruct.t
-  (** [sign mask k fips key digest] is the signature, a pair of {!Cstruct.t}s
+  (** [sign ~mask ~k ~key digest] is the signature, a pair of {!Cstruct.t}s
       representing [r] and [s] in big-endian.
 
       [digest] is the full digest of the actual message.
 
       [k], the random component, can either be provided, or is deterministically
-      derived as per RFC6979, using SHA256.  *)
+      derived as per RFC6979, using SHA256.
+
+      @raise Invalid_argument if [k] is unsuitable (leading to r or s being 0).
+ *)
 
   val verify : key:pub -> Cstruct.t * Cstruct.t -> Cstruct.t -> bool
-  (** [verify fips key (r, s) digest] verifies that the pair [(r, s)] is the signature
+  (** [verify ~key (r, s) digest] verifies that the pair [(r, s)] is the signature
       of [digest], the message digest, under the private counterpart to [key]. *)
 
   val massage : key:pub -> Cstruct.t -> Cstruct.t

--- a/pk/mirage_crypto_pk.mli
+++ b/pk/mirage_crypto_pk.mli
@@ -288,7 +288,7 @@ module Dsa : sig
 
   (** {1 DSA signature algorithm} *)
 
-  type priv = {
+  type priv = private {
     p  : Z.t ; (** Modulus *)
     q  : Z.t ; (** Subgroup order *)
     gg : Z.t ; (** Group Generator *)
@@ -299,7 +299,13 @@ module Dsa : sig
 
       {e [Sexplib] convertible}. *)
 
-  type pub  = {
+  val priv : ?fips:bool -> p:Z.t -> q:Z.t -> gg:Z.t -> x:Z.t -> y:Z.t ->
+    (priv, [> `Msg of string ]) result
+  (** [priv ~fips ~p ~q ~gg ~x ~y] constructs a private DSA key from the given
+      numbers. Will result in an error if parameters are ill-formed: same as
+      {!pub}, and additionally [0 < x < q] and [y = g ^ x mod p]. *)
+
+  type pub = private {
     p  : Z.t ;
     q  : Z.t ;
     gg : Z.t ;
@@ -308,6 +314,15 @@ module Dsa : sig
   (** Public key, a subset of {{!priv}private key}.
 
       {e [Sexplib] convertible}. *)
+
+  val pub : ?fips:bool -> p:Z.t -> q:Z.t -> gg:Z.t -> y:Z.t ->
+    (pub, [> `Msg of string ]) result
+  (** [pub ~fips ~p ~q ~gg ~y] constructs a public DSA key from the given
+      numbers. Will result in an error if the parameters are not well-formed:
+      [one < gg < p], [q] probabilistically a prime, [p] probabilistically
+      prime and odd, [0 < y < p], [q < p], and [p - 1 mod q = 0]. If [fips] is
+      specified and [true] (defaults to [false]), only FIPS-specified bit length
+      for [p] and [q] are accepted. *)
 
   type keysize = [ `Fips1024 | `Fips2048 | `Fips3072 | `Exactly of bits * bits ]
   (** Key size request. Three {e Fips} variants refer to FIPS-standardized

--- a/pk/mirage_crypto_pk.mli
+++ b/pk/mirage_crypto_pk.mli
@@ -386,7 +386,7 @@ module Dh : sig
   (** Raised if the public key is degenerate. Implies either badly malfunctioning
       DH on the other side, or an attack attempt. *)
 
-  type group = {
+  type group = private {
     p  : Z.t ;        (** modulus *)
     gg : Z.t ;        (** generator *)
     q  : Z.t option ; (** subgroup order; potentially unknown *)
@@ -394,6 +394,11 @@ module Dh : sig
   (** A DH group.
 
       {e [Sexplib] convertible}. *)
+
+  val group : p:Z.t -> gg:Z.t -> ?q:Z.t -> unit ->
+    (group, [> `Msg of string ]) result
+  (** [group ~p ~gg ~q ()] constructs a group if [p] is odd, a prime number,
+      and greater than [zero]. [gg] must be in the range [1 < gg < p]. *)
 
   type secret = private { x : Z.t }
   (** A private secret.
@@ -421,10 +426,10 @@ module Dh : sig
       group, a previously generated {!secret} and the other party's public
       message. It is [None] if [message] is degenerate. *)
 
-  val gen_group : ?g:Mirage_crypto_rng.g -> bits -> group
-  (** [gen_group bits] generates a random {!group} with modulus size [bits].
-      Uses a safe prime [p = 2q + 1] (with [q] prime) for the modulus and [2]
-      for the generator, such that [2^q = 1 mod p].
+  val gen_group : ?g:Mirage_crypto_rng.g -> bits:bits -> unit -> group
+  (** [gen_group ~g ~bits ()] generates a random {!group} with modulus size
+      [bits]. Uses a safe prime [p = 2q + 1] (with [q] prime) for the modulus
+      and [2] for the generator, such that [2^q = 1 mod p].
       Runtime is on the order of minute for 1024 bits.
 
       {b Note} The process might diverge if there are no suitable groups. This

--- a/pk/rsa.ml
+++ b/pk/rsa.ml
@@ -35,8 +35,6 @@ type pub = { e : Z_sexp.t ; n : Z_sexp.t } [@@deriving sexp]
 let minimum_octets = 12
 let minimum_bits = 8 * minimum_octets - 7
 
-let guard p err = if p then Ok () else Error err
-
 let pub ~e ~n =
   (* We cannot verify a public key being good (this would require to verify "n"
      being the multiplication of two prime numbers - figuring out which primes

--- a/pk/z_extra.ml
+++ b/pk/z_extra.ml
@@ -75,9 +75,12 @@ let pseudoprime z =
 let strip_factor ~f x =
   let rec go n x =
     let (x1, r) = Z.div_rem x f in
-    if r = Z.zero then go (succ n) x1 else (n, x) in
-  if Z.(~$2) <= f then go 0 x else invalid_arg "factor_count: f: %a" Z.pp_print f
-
+    if r = Z.zero then go (succ n) x1 else Ok (n, x)
+  in
+  if Z.(~$2) <= f then
+    go 0 x
+  else
+    Rresult.R.error_msgf "factor_count: f: %a" Z.pp_print f
 
 let gen ?g n =
   if n < Z.one then invalid_arg "Rng.gen: non-positive: %a" Z.pp_print n;

--- a/tests/test_dh.ml
+++ b/tests/test_dh.ml
@@ -6,7 +6,7 @@ open Test_common
 
 let dh_selftest ~bits n =
   "selftest" >:: times ~n @@ fun _ ->
-    let p = Dh.gen_group bits in
+    let p = Dh.gen_group ~bits () in
     let (s1, m1) = Dh.gen_key p
     and (s2, m2) = Dh.gen_key p in
     let sh1 = Dh.shared p s1 m2

--- a/tests/test_dsa.ml
+++ b/tests/test_dsa.ml
@@ -33,7 +33,9 @@ let dsa_test ~priv ~msg ?k ~r ~s ~hash _ =
 let params ~p ~q ~g = Cstruct.(of_hex p, of_hex q, of_hex g)
 
 let priv_of f ~p ~q ~gg ~x ~y =
-  { Dsa.p = f p ; q = f q ; gg = f gg ; x = f x ; y = f y }
+  match Dsa.priv ~fips:true ~p:(f p) ~q:(f q) ~gg:(f gg) ~x:(f x) ~y:(f y) with
+  | Ok dsa -> dsa
+  | Error (`Msg m) -> invalid_arg "bad DSA private key %s" m
 
 let priv_of_cs  = priv_of Z_extra.of_cstruct_be
 let priv_of_hex = priv_of (fun cs -> hex cs |> Z_extra.of_cstruct_be)

--- a/tests/test_rsa.ml
+++ b/tests/test_rsa.ml
@@ -14,12 +14,22 @@ let random_is seed =
 
 let gen_rsa ~bits =
   let e     = Z.(if bits < 24 then ~$3 else ~$0x10001) in
-  let key   = Rsa.(generate ~e bits) in
+  let key   = Rsa.(generate ~e ~bits ()) in
   let key_s = Sexplib.Sexp.to_string_hum Rsa.(sexp_of_priv key) in
   assert_equal
     ~msg:Printf.(sprintf "key size not %d bits:\n%s" bits key_s)
     bits Rsa.(priv_bits key);
   (key, key_s)
+
+let rsa_priv_of_primes_regression _ =
+  let e = Z.of_string "65537"
+  and p = Z.of_string "63541376186162969"
+  and q = Z.of_string "31114890003960709"
+  in
+  match Rsa.priv_of_primes ~e ~p ~q with
+  | exception _ -> assert_failure "expected an error"
+  | Error _ -> () (* expected since there's no multiplicative inverse of e with p and q (e is not coprime to q-1) *)
+  | Ok _ -> assert_failure "expected an error"
 
 let rsa_selftest ~bits n =
   "selftest" >:: times ~n @@ fun _ ->
@@ -106,109 +116,115 @@ let rsa_pss_sign_selftest ~bits n =
       |> assert_bool "invert 2"
 
 let rsa_pkcs1_cases =
-  let k ~n ~d ~e = (vz n, vz d, vz e) in
+  let key () =
+    let n = vz "c8a2069182394a2ab7c3f4190c15589c56a2d4bc42dca675b34cc950e24663048441e8aa593b2bc59e198b8c257e882120c62336e5cc745012c7ffb063eebe53f3c6504cba6cfe51baa3b6d1074b2f398171f4b1982f4d65caf882ea4d56f32ab57d0c44e6ad4e9cf57a4339eb6962406e350c1b15397183fbf1f0353c9fc991"
+    and d = vz "5dfcb111072d29565ba1db3ec48f57645d9d8804ed598a4d470268a89067a2c921dff24ba2e37a3ce834555000dc868ee6588b7493303528b1b3a94f0b71730cf1e86fca5aeedc3afa16f65c0189d810ddcd81049ebbd0391868c50edec958b3a2aaeff6a575897e2f20a3ab5455c1bfa55010ac51a7799b1ff8483644a3d425"
+    and e = vz "10001"
+    in
+    match Rsa.priv_of_exp ~e ~d ~n () with
+    | Error (`Msg m) -> invalid_arg "bad key %s" m
+    | Ok key -> key, Rsa.pub_of_priv key
+  in
 
-  let case ~key:(n, d, e) ~hash ~msg ~sgn = test_case @@ fun _ ->
+  let case ~hash ~msg ~sgn = test_case @@ fun _ ->
     let msg = vx msg and sgn = vx sgn in
-    Rsa.(PKCS1.sign ~hash ~key:(priv_of_exp ~e ~d n) (`Message msg))
+    let key, public = key () in
+    Rsa.(PKCS1.sign ~hash ~key (`Message msg))
       |> assert_cs_equal ~msg:"recomputing sig:" sgn ;
-    Rsa.(PKCS1.verify ~hashp:any ~key:{e; n} ~signature:sgn (`Message msg))
+    Rsa.(PKCS1.verify ~hashp:any ~key:public ~signature:sgn (`Message msg))
       |> assert_bool "sig verification" in
-
-  let key = k
-    ~n:"c8a2069182394a2ab7c3f4190c15589c56a2d4bc42dca675b34cc950e24663048441e8aa593b2bc59e198b8c257e882120c62336e5cc745012c7ffb063eebe53f3c6504cba6cfe51baa3b6d1074b2f398171f4b1982f4d65caf882ea4d56f32ab57d0c44e6ad4e9cf57a4339eb6962406e350c1b15397183fbf1f0353c9fc991"
-    ~d:"5dfcb111072d29565ba1db3ec48f57645d9d8804ed598a4d470268a89067a2c921dff24ba2e37a3ce834555000dc868ee6588b7493303528b1b3a94f0b71730cf1e86fca5aeedc3afa16f65c0189d810ddcd81049ebbd0391868c50edec958b3a2aaeff6a575897e2f20a3ab5455c1bfa55010ac51a7799b1ff8483644a3d425"
-    ~e:"10001" in
 
   "FIPS 186-2 Test Vectors (1024 bits)" >::: [
 
-    case ~key ~hash:`SHA1
+    case ~hash:`SHA1
     ~msg:"e8312742ae23c456ef28a23142c4490895832765dadce02afe5be5d31b0048fbeee2cf218b1747ad4fd81a2e17e124e6af17c3888e6d2d40c00807f423a233cad62ce9eaefb709856c94af166dba08e7a06965d7fc0d8e5cb26559c460e47bc088589d2242c9b3e62da4896fab199e144ec136db8d84ab84bcba04ca3b90c8e5"
     ~sgn:"28928e19eb86f9c00070a59edf6bf8433a45df495cd1c73613c2129840f48c4a2c24f11df79bc5c0782bcedde97dbbb2acc6e512d19f085027cd575038453d04905413e947e6e1dddbeb3535cdb3d8971fe0200506941056f21243503c83eadde053ed866c0e0250beddd927a08212aa8ac0efd61631ef89d8d049efb36bb35f"
 
-  ; case ~key ~hash:`SHA1
+  ; case ~hash:`SHA1
     ~msg:"4c95073dac19d0256eaadff3505910e431dd50018136afeaf690b7d18069fcc980f6f54135c30acb769bee23a7a72f6ce6d90cbc858c86dbbd64ba48a07c6d7d50c0e9746f97086ad6c68ee38a91bbeeeb2221aa2f2fb4090fd820d4c0ce5ff025ba8adf43ddef89f5f3653de15edcf3aa8038d4686960fc55b2917ec8a8f9a8"
     ~sgn:"53ab600a41c71393a271b0f32f521963087e56ebd7ad040e4ee8aa7c450ad18ac3c6a05d4ae8913e763cfe9623bd9cb1eb4bed1a38200500fa7df3d95dea485f032a0ab0c6589678f9e8391b5c2b1392997ac9f82f1d168878916aace9ac7455808056af8155231a29f42904b7ab87a5d71ed6395ee0a9d024b0ca3d01fd7150"
 
-  ; case ~key ~hash:`SHA1
+  ; case ~hash:`SHA1
     ~msg:"e075ad4b0f9b5b20376e467a1a35e308793ba38ed983d03887b8b82eda630e68b8618dc45b93de5555d7bcfed23756401e61f5516757de6ec3687a71755fb4a66cfaa3db0c9e69b631485b4c71c762eea229a0469c7357a440950792ba9cd7ae022a36b9a923c2ebd2aa69897f4cceba0e7aee97033d03810725a9b731833f27"
     ~sgn:"642609ce084f479271df596480252e2f892b3e7982dff95994c3eeda787f80f3f6198bbce33ec5515378d4b571d7186078b75b43aed11d342547386c5696eb3799a0b28475e54cd4ca7d036dcd8a11f5e10806f7d3b8cc4fcb3e93e857be958344a34e126809c15b3d33661cf57bf5c338f07acced60f14019335c152d86b3b2"
 
-  ; case ~key ~hash:`SHA224
+  ; case ~hash:`SHA224
     ~msg:"e567a39ae4e5ef9b6801ea0561b72a5d4b5f385f0532fc9fe10a7570f869ae05c0bdedd6e0e22d4542e9ce826a188cac0731ae39c8f87f9771ef02132e64e2fb27ada8ff54b330dd93ad5e3ef82e0dda646248e35994bda10cf46e5abc98aa7443c03cddeb5ee2ab82d60100b1029631897970275f119d05daa2220a4a0defba"
     ~sgn:"5aa5033381bdd0acce332dd314daf008acaa9e835f832979891d1bda2b55d5eae35c479c06cac5bf33f432c8c0a5549d1d1b29c5e2589024d27800a0c235a61532c203cbc406ac6ecf63f52ae771b97c08e4b108ec916900e5a11b1d48cca86ca5a5a799ed32e99c815cef04cf8eb55223bfd4d9c3449264b60061bc3684bc82"
 
-  ; case ~key ~hash:`SHA256
+  ; case ~hash:`SHA256
     ~msg:"e567a39ae4e5ef9b6801ea0561b72a5d4b5f385f0532fc9fe10a7570f869ae05c0bdedd6e0e22d4542e9ce826a188cac0731ae39c8f87f9771ef02132e64e2fb27ada8ff54b330dd93ad5e3ef82e0dda646248e35994bda10cf46e5abc98aa7443c03cddeb5ee2ab82d60100b1029631897970275f119d05daa2220a4a0defba"
     ~sgn:"0e7cdd121e40323ca6115d1ec6d1f9561738455f0e9e1cd858e8b566ae2da5e8ee63d8f15c3cdd88027e13406db609369c88ca99b34fa156c7ee62bc5a3923bb5a1edabd45c1a422aafcbb47e0947f35cfef87970b4b713162b21916cafb8c864a3e5b9ffc989401d4eae992312a32c5bc88abbb45f99ac885b54d6b8e61b6ec"
 
-  ; case ~key ~hash:`SHA384
+  ; case ~hash:`SHA384
     ~msg:"e567a39ae4e5ef9b6801ea0561b72a5d4b5f385f0532fc9fe10a7570f869ae05c0bdedd6e0e22d4542e9ce826a188cac0731ae39c8f87f9771ef02132e64e2fb27ada8ff54b330dd93ad5e3ef82e0dda646248e35994bda10cf46e5abc98aa7443c03cddeb5ee2ab82d60100b1029631897970275f119d05daa2220a4a0defba"
     ~sgn:"1689a8523919ac77cc997ebc59cb908872d88b2855a309ead2779b888b22b4232da9b93bb19b32c1db77ad738c6e43361e9eb6b1a37c49a8f3c7c7ae7e784d19a62138741293e49b1831c0c3617eb43c56706d83314953470636441086419ab9e6fd1ec4f9d5cc6544815d1e02ed96a3ae64c6998b2cf238e79a12164352d12a"
 
-  ; case ~key ~hash:`SHA512
+  ; case ~hash:`SHA512
     ~msg:"e567a39ae4e5ef9b6801ea0561b72a5d4b5f385f0532fc9fe10a7570f869ae05c0bdedd6e0e22d4542e9ce826a188cac0731ae39c8f87f9771ef02132e64e2fb27ada8ff54b330dd93ad5e3ef82e0dda646248e35994bda10cf46e5abc98aa7443c03cddeb5ee2ab82d60100b1029631897970275f119d05daa2220a4a0defba"
     ~sgn:"bf3ff2c69675f1b8ed421021801fb4ce29a757f7f8869ce436d0d75ab749efc8b903d9f9cb214686147f12f3335fa936689c192f310ae3c5d75493f44b24bc1cd3501584aaa5004b65a8716d1eda7240ad8a529d5a0cf169f4054b450e076ee0d41a0011c557aa69a84a8104c909201d60fe39c79e684347ef4d144ea18f7a4e"
   ]
 
 let rsa_pss_cases =
-  let k ~n ~d ~e = (vz n, vz d, vz e) in
+  let key () =
+    let n = vz "bcb47b2e0dafcba81ff2a2b5cb115ca7e757184c9d72bcdcda707a146b3b4e29989ddc660bd694865b932b71ca24a335cf4d339c719183e6222e4c9ea6875acd528a49ba21863fe08147c3a47e41990b51a03f77d22137f8d74c43a5a45f4e9e18a2d15db051dc89385db9cf8374b63a8cc88113710e6d8179075b7dc79ee76b"
+    and d = vz "383a6f19e1ea27fd08c7fbc3bfa684bd6329888c0bbe4c98625e7181f411cfd0853144a3039404dda41bce2e31d588ec57c0e148146f0fa65b39008ba5835f829ba35ae2f155d61b8a12581b99c927fd2f22252c5e73cba4a610db3973e019ee0f95130d4319ed413432f2e5e20d5215cdd27c2164206b3f80edee51938a25c1"
+    and e = vz "10001"
+    in
+    match Rsa.priv_of_exp ~e ~d ~n () with
+    | Error (`Msg m) -> invalid_arg "bad key %s" m
+    | Ok key -> key, Rsa.pub_of_priv key
+  and salt = "6f2841166a64471d4f0b8ed0dbb7db32161da13b"
+  in
 
-  let case ~key:(n, d, e) ~hash ~salt ~msg ~sgn = test_case @@ fun _ ->
+  let case ~hash ~msg ~sgn = test_case @@ fun _ ->
     let module H = (val (Hash.module_of hash)) in
     let module Pss = Rsa.PSS (H) in
     let msg = vx msg and sgn = vx sgn and salt = vx salt in
+    let key, public = key () in
     let slen = Cstruct.len salt in
-    Pss.sign ~g:(random_is salt) ~slen
-             ~mask:`No ~key:Rsa.(priv_of_exp ~e ~d n) (`Message msg)
+    Pss.sign ~g:(random_is salt) ~slen ~mask:`No ~key (`Message msg)
       |> assert_cs_equal ~msg:"recomputing sig:" sgn ;
-    Pss.verify ~key:{Rsa.e; n} ~slen ~signature:sgn (`Message msg)
+    Pss.verify ~key:public ~slen ~signature:sgn (`Message msg)
       |> assert_bool "sig verification" in
-
-  let key = k
-    ~n:"bcb47b2e0dafcba81ff2a2b5cb115ca7e757184c9d72bcdcda707a146b3b4e29989ddc660bd694865b932b71ca24a335cf4d339c719183e6222e4c9ea6875acd528a49ba21863fe08147c3a47e41990b51a03f77d22137f8d74c43a5a45f4e9e18a2d15db051dc89385db9cf8374b63a8cc88113710e6d8179075b7dc79ee76b"
-    ~d:"383a6f19e1ea27fd08c7fbc3bfa684bd6329888c0bbe4c98625e7181f411cfd0853144a3039404dda41bce2e31d588ec57c0e148146f0fa65b39008ba5835f829ba35ae2f155d61b8a12581b99c927fd2f22252c5e73cba4a610db3973e019ee0f95130d4319ed413432f2e5e20d5215cdd27c2164206b3f80edee51938a25c1"
-    ~e:"10001"
-
-  and salt = "6f2841166a64471d4f0b8ed0dbb7db32161da13b" in
 
   "FIPS 186-2 Test Vectors (1024 bits)" >::: [
 
-    case ~key ~hash:`SHA1 ~salt
+    case ~hash:`SHA1
     ~msg:"1248f62a4389f42f7b4bb131053d6c88a994db2075b912ccbe3ea7dc611714f14e075c104858f2f6e6cfd6abdedf015a821d03608bf4eba3169a6725ec422cd9069498b5515a9608ae7cc30e3d2ecfc1db6825f3e996ce9a5092926bc1cf61aa42d7f240e6f7aa0edb38bf81aa929d66bb5d890018088458720d72d569247b0c"
     ~sgn:"682cf53c1145d22a50caa9eb1a9ba70670c5915e0fdfde6457a765de2a8fe12de9794172a78d14e668d498acedad616504bb1764d094607070080592c3a69c343d982bd77865873d35e24822caf43443cc10249af6a1e26ef344f28b9ef6f14e09ad839748e5148bcceb0fd2aa63709cb48975cbf9c7b49abc66a1dc6cb5b31a"
 
-  ; case ~key ~hash:`SHA1 ~salt
+  ; case ~hash:`SHA1
     ~msg:"9968809a557bb4f892039ff2b6a0efcd06523624bc3b9ad359a7cf143c4942e874c797b9d37a563d436fe19d5db1aad738caa2617f87f50fc7fcf4361fc85212e89a9465e7f4c361982f64c8c5c0aa5258b9e94f6e934e8dac2ace7cd6095c909de85fe7b973632c384d0ebb165556050d28f236aee70e16b13a432d8a94c62b"
     ~sgn:"8f5ea7037367e0db75670504085790acd6d97d96f51e76df916a0c2e4cd66e1ab51c4cd8e2c3e4ef781f638ad65dc49c8d6d7f6930f80b6ae199ea283a8924925a50edab79bb3f34861ffa8b2f96fdf9f8cad3d3f8f025478c81f316da61b0d6a7f71b9068efdfb33c21983a922f4669280d8e84f963ff885ef56dd3f50381db"
 
-  ; case ~key ~hash:`SHA224 ~salt
+  ; case ~hash:`SHA224
     ~msg:"1248f62a4389f42f7b4bb131053d6c88a994db2075b912ccbe3ea7dc611714f14e075c104858f2f6e6cfd6abdedf015a821d03608bf4eba3169a6725ec422cd9069498b5515a9608ae7cc30e3d2ecfc1db6825f3e996ce9a5092926bc1cf61aa42d7f240e6f7aa0edb38bf81aa929d66bb5d890018088458720d72d569247b0c"
     ~sgn:"53d859c9f10abf1c00284a4b55bf2bd84d8e313b4f3c35b8dec7bc3afe39b9b8a155418ead1931895769ce2340be2091f2385bbcf10d9e92bcf5d0e2960d10e792e7d865c64e50d19ffa13e52817d7d8d8db34392c2374a2e9b69184f92a4ad9b1b8bae99ca614d204b65a438e38dbbfc8c7cc44ed5677af70ce6c4f951f0244"
 
-  ; case ~key ~hash:`SHA256 ~salt
+  ; case ~hash:`SHA256
     ~msg:"1248f62a4389f42f7b4bb131053d6c88a994db2075b912ccbe3ea7dc611714f14e075c104858f2f6e6cfd6abdedf015a821d03608bf4eba3169a6725ec422cd9069498b5515a9608ae7cc30e3d2ecfc1db6825f3e996ce9a5092926bc1cf61aa42d7f240e6f7aa0edb38bf81aa929d66bb5d890018088458720d72d569247b0c"
     ~sgn:"7b1d37278e549898d4084e2210c4a9961edfe7b5963550cca1904248c8681513539017820f0e9bd074b9f8a067b9fefff7f1fa20bf2d0c75015ff020b2210cc7f79034fedf68e8d44a007abf4dd82c26e8b00393723aea15abfbc22941c8cf79481718c008da713fb8f54cb3fca890bde1137314334b9b0a18515bfa48e5ccd0"
 
-  ; case ~key ~hash:`SHA384 ~salt
+  ; case ~hash:`SHA384
     ~msg:"1248f62a4389f42f7b4bb131053d6c88a994db2075b912ccbe3ea7dc611714f14e075c104858f2f6e6cfd6abdedf015a821d03608bf4eba3169a6725ec422cd9069498b5515a9608ae7cc30e3d2ecfc1db6825f3e996ce9a5092926bc1cf61aa42d7f240e6f7aa0edb38bf81aa929d66bb5d890018088458720d72d569247b0c"
     ~sgn:"8f16c807bef3ed6f74ee7ff5c360a5428c6c2f105178b58ff7d073e566dad6e7718d3129c768cd5a9666de2b6c947177b45709dc7cd0f43b0ba6fc75578e1196acc15ca3afe4a78c144cb6885c1cc815f7f98925bc04ad2ff20fc1068b045d9450e2a1dcf5a161ceabba2b0b66c7354fdb80fa1d729e5f976387f24a697a7e56"
 
-  ; case ~key ~hash:`SHA512 ~salt
+  ; case ~hash:`SHA512
     ~msg:"1248f62a4389f42f7b4bb131053d6c88a994db2075b912ccbe3ea7dc611714f14e075c104858f2f6e6cfd6abdedf015a821d03608bf4eba3169a6725ec422cd9069498b5515a9608ae7cc30e3d2ecfc1db6825f3e996ce9a5092926bc1cf61aa42d7f240e6f7aa0edb38bf81aa929d66bb5d890018088458720d72d569247b0c"
     ~sgn:"a833ba31634f8773e4fe6ea0c69e1a23766a939d34b32fc78b774b22e46a646c25e6e1062d234ed48b1aba0f830529ff6afc296cc8dc207bbc15391623beac5f6c3db557ca49d0e42c962de95b5ff548cff970f5c73f439cfe82d3907be60240f56b6a4259cc96dfd8fe02a0bfa26e0223f68214428fff0ae40162198cc5cbd1"
   ]
 
 let suite = [
   "RSA" >::: [
-    (* rsa_selftest ~bits:8    1000 ; *)
-    rsa_selftest ~bits:16   1000 ;
+    rsa_selftest ~bits:89   100  ;
     rsa_selftest ~bits:131  100  ;
     rsa_selftest ~bits:1024 10   ;
+    rsa_selftest ~bits:2048 10   ;
   ] ;
 
   "RSA-PKCS1-ENC" >::: [
-    rsa_pkcs1_encrypt_selftest ~bits:111 100 ;
+    rsa_pkcs1_encrypt_selftest ~bits:111 1000 ;
     rsa_pkcs1_encrypt_selftest ~bits:512 10 ;
   ] ;
 
@@ -230,5 +246,9 @@ let suite = [
     rsa_pss_sign_selftest ~bits:512 15 ;
     rsa_pss_sign_selftest ~bits:513 15 ;
     rsa_pss_cases
-  ];
+  ] ;
+
+  "RSA-regression" >::: [
+    test_case rsa_priv_of_primes_regression
+  ] ;
 ]


### PR DESCRIPTION
validate before constructing public and private keys. use result instead of exceptions in of_exp, of_prime

remove well_formed, which is now implicit.