### PR TITLE
Update test.yml

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,28 +1,39 @@
 name: Crypto
+
 on: [push, pull_request]
+
 jobs:
   tests:
     name: Tests
-    runs-on: ${{ matrix.operating-system }}
+
     strategy:
       fail-fast: false
       matrix:
-        ocaml-version: [ '4.08.1', '4.09.0', '4.10.0' ]
+        ocaml-version: ["4.10.0", "4.09.0", "4.08.1"]
         operating-system: [macos-latest, ubuntu-latest, windows-latest]
+
+    runs-on: ${{ matrix.operating-system }}
+
     steps:
-    - uses: actions/checkout@master
-    - uses: avsm/setup-ocaml@master
-      with:
-        ocaml-version: ${{ matrix.ocaml-version }}
-    - name: Deps
-      run: |
-        opam pin add -n mirage-crypto.dev .
-        opam pin add -n mirage-crypto-rng.dev .
-        opam pin add -n mirage-crypto-pk.dev .
-        opam pin add -n mirage-crypto-entropy.dev .
-        opam depext -y mirage-crypto mirage-crypto-rng mirage-crypto-pk mirage-crypto-entropy
-        opam install -t --deps-only .
-    - name: Build
-      run: opam exec -- dune build
-    - name: Test
-      run: opam exec -- dune runtest
+      - name: Checkout code
+        uses: actions/checkout@v2.0.0
+
+      - name: Use OCaml ${{ matrix.ocaml-version }}
+        uses: avsm/setup-ocaml@v1.0
+        with:
+          ocaml-version: ${{ matrix.ocaml-version }}
+
+      - name: Install dependencies
+        run: |
+          opam pin add -n mirage-crypto.dev .
+          opam pin add -n mirage-crypto-rng.dev .
+          opam pin add -n mirage-crypto-pk.dev .
+          opam pin add -n mirage-crypto-entropy.dev .
+          opam depext -y mirage-crypto mirage-crypto-rng mirage-crypto-pk mirage-crypto-entropy
+          opam install -t --deps-only .
+
+      - name: Build
+        run: opam exec -- dune build
+
+      - name: Test
+        run: opam exec -- dune runtest


### PR DESCRIPTION
Specifying action version by a branch name instead of a git tag is dangerous because it can break a build at an unintended time. Ideally, it should be specified by a commit hash, but let's use the common method (git tag) for now.