### PR TITLE
mirage-crypto: remove ocplib-endian dependency, use Bytes.set_int64 in Counters (also remove Uncommon.Option in favour of stdlib)

### DIFF
--- a/mirage-crypto-entropy.opam
+++ b/mirage-crypto-entropy.opam
@@ -14,7 +14,7 @@ build: [
 ]
 depends: [
   "dune" {>= "1.7.0"}
-  "ocaml" {>= "4.07.0"}
+  "ocaml" {>= "4.08.0"}
   "cstruct" {>= "4.0.0"}
   "mirage-runtime" {>= "3.7.0"}
   "lwt" {>= "4.0.0"}

--- a/mirage-crypto-pk.opam
+++ b/mirage-crypto-pk.opam
@@ -14,7 +14,7 @@ build: [ ["dune" "subst"] {pinned}
 
 depends: [
   "conf-gmp-powm-sec" {build}
-  "ocaml" {>= "4.07.0"}
+  "ocaml" {>= "4.08.0"}
   "dune" {>= "1.7"}
   "ounit" {with-test}
   "randomconv" {with-test & >= "0.1.3"}

--- a/mirage-crypto-rng.opam
+++ b/mirage-crypto-rng.opam
@@ -13,7 +13,7 @@ build: [ ["dune" "subst"] {pinned}
          ["dune" "runtest" "-p" name "-j" jobs] {with-test} ]
 
 depends: [
-  "ocaml" {>= "4.07.0"}
+  "ocaml" {>= "4.08.0"}
   "dune" {>= "1.7"}
   "dune-configurator"
   "ounit" {with-test}

--- a/mirage-crypto.opam
+++ b/mirage-crypto.opam
@@ -14,13 +14,12 @@ build: [ ["dune" "subst"] {pinned}
 
 depends: [
   "conf-pkg-config" {build}
-  "ocaml" {>= "4.07.0"}
+  "ocaml" {>= "4.08.0"}
   "dune" {>= "1.7"}
   "dune-configurator" {>= "2.0.0"}
   "cpuid" {build}
   "ounit" {with-test}
   "cstruct" {>="3.2.0"}
-  "ocplib-endian"
 ]
 depopts: [
   "mirage-xen-posix"

--- a/pk/dh.ml
+++ b/pk/dh.ml
@@ -81,10 +81,11 @@ let key_of_secret group ~s =
  *)
 let rec gen_key ?g ?bits ({ p; q; _ } as group) =
   let pb = Z.numbits p in
-  let s = Option.(
-    imin (get_or exp_size pb bits)
-         (q >>| Z.numbits |> get ~def:pb))
-    |> Z_extra.gen_bits ?g ~msb:1 in
+  let s =
+    imin (Option.value bits ~default:pb |> exp_size)
+         (Option.fold ~none:pb ~some:Z.numbits q)
+    |> Z_extra.gen_bits ?g ~msb:1
+  in
   try key_of_secret_z group s with Invalid_key -> gen_key ?g ?bits group
 
 let shared { group ; x } cs =

--- a/rng/mirage_crypto_rng.ml
+++ b/rng/mirage_crypto_rng.ml
@@ -43,8 +43,8 @@ end
 
 let create (type a) ?g ?seed ?(strict=false) (m : a generator) =
   let module M = (val m) in
-  let g = Option.get_or M.create () g in
-  seed |> Option.cond ~f:(M.reseed ~g) ;
+  let g = Option.value g ~default:(M.create ()) in
+  Option.iter (M.reseed ~g) seed;
   Generator (g, strict, m)
 
 let generator = ref (create (module Null))

--- a/src/cipher_block.ml
+++ b/src/cipher_block.ml
@@ -112,7 +112,7 @@ module Counters = struct
     val unsafe_count_into : ctr -> Native.buffer -> int -> blocks:int -> unit
   end
 
-  let _tmp = Bytes.make 32 '\x00'
+  let _tmp = Bytes.make 16 '\x00'
 
   module C64be = struct
     type ctr = int64

--- a/src/cipher_block.ml
+++ b/src/cipher_block.ml
@@ -114,15 +114,13 @@ module Counters = struct
 
   let _tmp = Bytes.make 32 '\x00'
 
-  open EndianBytes.BigEndian_unsafe
-
   module C64be = struct
     type ctr = int64
     let size = 8
     let of_cstruct cs = BE.get_uint64 cs 0
     let add = Int64.add
     let unsafe_count_into t buf off ~blocks =
-      set_int64 _tmp 0 t;
+      Bytes.set_int64_be _tmp 0 t;
       Native.count8be _tmp buf off ~blocks
   end
 
@@ -135,7 +133,7 @@ module Counters = struct
       let flip = if Int64.logxor w0 w0' < 0L then w0' > w0 else w0' < w0 in
       ((if flip then Int64.succ w1 else w1), w0')
     let unsafe_count_into (w1, w0) buf off ~blocks =
-      set_int64 _tmp 0 w1; set_int64 _tmp 8 w0;
+      Bytes.set_int64_be _tmp 0 w1; Bytes.set_int64_be _tmp 8 w0;
       Native.count16be _tmp buf off ~blocks
   end
 
@@ -145,7 +143,7 @@ module Counters = struct
       let hi = 0xffffffff00000000L and lo = 0x00000000ffffffffL in
       (w1, Int64.(logor (logand hi w0) (add n w0 |> logand lo)))
     let unsafe_count_into (w1, w0) buf off ~blocks =
-      set_int64 _tmp 0 w1; set_int64 _tmp 8 w0;
+      Bytes.set_int64_be _tmp 0 w1; Bytes.set_int64_be _tmp 8 w0;
       Native.count16be4 _tmp buf off ~blocks
   end
 end

--- a/src/dune
+++ b/src/dune
@@ -1,7 +1,7 @@
 (library
   (name mirage_crypto)
   (public_name mirage-crypto)
-  (libraries cstruct ocplib-endian)
+  (libraries cstruct)
   (private_modules ccm cipher_block cipher_stream hash native uncommon)
   (c_names misc
            md5 sha1 sha256 sha512 hash_stubs

--- a/src/mirage_crypto.mli
+++ b/src/mirage_crypto.mli
@@ -29,16 +29,6 @@ module Uncommon : sig
 
       @raise Division_by_zero when [y < 1]. *)
 
-  module Option : sig
-    val v_map : def:'b -> f:('a -> 'b) -> 'a option -> 'b
-    val map   : f:('a -> 'b) -> 'a option -> 'b option
-    val get   : def:'a -> 'a option -> 'a
-    val get_or : ('a -> 'b) -> 'a -> 'b option -> 'b
-    val cond : f:('a -> 'b) -> 'a option -> unit
-    val (>>=) : 'a option -> ('a -> 'b option) -> 'b option
-    val (>>|) : 'a option -> ('a -> 'b) -> 'b option
-  end
-
   (** Addons to {!Cstruct}. *)
   module Cs : sig
 

--- a/src/uncommon.ml
+++ b/src/uncommon.ml
@@ -13,30 +13,6 @@ let (//) x y =
 let imin (a : int) b = if a < b then a else b
 let imax (a : int) b = if a < b then b else a
 
-module Option = struct
-
-  let get_or f x = function None -> f x | Some y -> y
-
-  let (>>=) a fb = match a with Some x -> fb x | _ -> None
-  let (>>|) a f = match a with Some x -> Some (f x) | _ -> None
-
-  let v_map ~def ~f = function
-    | Some x -> f x
-    | None   -> def
-
-  let get ~def = function
-    | Some x -> x
-    | None   -> def
-
-  let map ~f = function
-    | Some x -> Some (f x)
-    | None   -> None
-
-  let cond ~f = function
-    | Some x -> ignore (f x)
-    | None   -> ()
-end
-
 type 'a iter = ('a -> unit) -> unit
 
 let iter2 a b   f = f a; f b


### PR DESCRIPTION
to shrink the dependency cone