### PR TITLE
Runtime detection of CPU features

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,21 +41,3 @@ Unix:
 ```OCaml
 let () = Mirage_crypto_rng_unix.initialize ()
 ```
-
-#### Illegal instructions
-
-```
-Program terminated with signal SIGILL, Illegal instruction.
-#0  _mm_aeskeygenassist_si128 (__C=<optimized out>, __X=...)
-```
-
-`Mirage_crypto` has CPU acceleration support (`SSE2`+`AES-NI`), but no run-time
-autodetection yet. You compiled the library with acceleration, but you are using
-it on a machine that does not support it.
-
-The environment variable `MIRAGE_CRYPTO_ACCELERATE` can be used to override
-detection:
-
-- `MIRAGE_CRYPTO_ACCELERATE=false dune build` force-disables non-portable code.
-- `MIRAGE_CRYPTO_ACCELERATE=true dune build` force-enables non-portable code.
-- Otherwise, it matches the capabilities of the build machine.

--- a/config/cfg.ml
+++ b/config/cfg.ml
@@ -1,15 +1,13 @@
 let evar  = "MIRAGE_CRYPTO_ACCELERATE"
-let needs = [`SSSE3; `AES; `PCLMULQDQ]
 let flags = ["-DACCELERATE"; "-mssse3"; "-maes"; "-mpclmul"]
 let std_flags = ["--std=c99"; "-Wall"; "-Wextra"; "-Wpedantic"; "-O3"]
 
 let _ =
-  let auto = match Cpuid.supports needs with Ok true -> flags | _ -> [] in
   let accelerate_flags = match Sys.getenv evar with
     | "true" -> flags
     | "false" -> []
-    | _ -> auto
-    | exception Not_found -> auto
+    | _ -> flags
+    | exception Not_found -> flags
   in
   let ent_flags =
     let c = Configurator.V1.create "mirage-crypto" in

--- a/config/cfg.ml
+++ b/config/cfg.ml
@@ -13,7 +13,7 @@ let _ =
   in
   let ent_flags =
     match arch with
-    | "x86_64" | "amd64" | "x86" -> [ "-mrdrnd" ; "-mrdseed" ]
+    | "x86_64" | "amd64" | "x86" -> [ "-DENTROPY"; "-mrdrnd"; "-mrdseed" ]
     | _ -> []
   in
   let fs = std_flags @ ent_flags @ accelerate_flags in

--- a/config/cfg.ml
+++ b/config/cfg.ml
@@ -8,7 +8,7 @@ let _ =
   in
   let accelerate_flags =
     match arch with
-    | "x86_64" -> [ "-DACCELERATE"; "-mssse3"; "-maes"; "-mpclmul" ]
+    | "x86_64" | "amd64" -> [ "-DACCELERATE"; "-mssse3"; "-maes"; "-mpclmul" ]
     | _ -> []
   in
   let ent_flags =

--- a/config/cfg.ml
+++ b/config/cfg.ml
@@ -1,11 +1,18 @@
-let accelerate_flags = ["-mssse3"; "-maes"; "-mpclmul"]
 let std_flags = ["--std=c99"; "-Wall"; "-Wextra"; "-Wpedantic"; "-O3"]
 
 let _ =
-  let ent_flags =
-    let c = Configurator.V1.create "mirage-crypto" in
+  let c = Configurator.V1.create "mirage-crypto" in
+  let arch =
     let arch = Configurator.V1.Process.run c "uname" ["-m"] in
-    match String.trim arch.Configurator.V1.Process.stdout with
+    String.trim arch.Configurator.V1.Process.stdout
+  in
+  let accelerate_flags =
+    match arch with
+    | "x86_64" -> [ "-DACCELERATE"; "-mssse3"; "-maes"; "-mpclmul" ]
+    | _ -> []
+  in
+  let ent_flags =
+    match arch with
     | "x86_64" | "amd64" | "x86" -> [ "-mrdrnd" ; "-mrdseed" ]
     | _ -> []
   in

--- a/config/cfg.ml
+++ b/config/cfg.ml
@@ -1,14 +1,7 @@
-let evar  = "MIRAGE_CRYPTO_ACCELERATE"
-let flags = ["-DACCELERATE"; "-mssse3"; "-maes"; "-mpclmul"]
+let accelerate_flags = ["-mssse3"; "-maes"; "-mpclmul"]
 let std_flags = ["--std=c99"; "-Wall"; "-Wextra"; "-Wpedantic"; "-O3"]
 
 let _ =
-  let accelerate_flags = match Sys.getenv evar with
-    | "true" -> flags
-    | "false" -> []
-    | _ -> flags
-    | exception Not_found -> flags
-  in
   let ent_flags =
     let c = Configurator.V1.create "mirage-crypto" in
     let arch = Configurator.V1.Process.run c "uname" ["-m"] in

--- a/config/dune
+++ b/config/dune
@@ -1,3 +1,3 @@
 (executables
   (names cfg)
-  (libraries dune-configurator cpuid))
+  (libraries dune-configurator))

--- a/entropy/mirage_crypto_entropy.ml
+++ b/entropy/mirage_crypto_entropy.ml
@@ -33,9 +33,6 @@ module Cpu_native = struct
   external unchecked_random : unit -> int  = "caml_cpu_unchecked_random" [@@noalloc]
   external checked_random : unit -> int  = "caml_cpu_checked_random" [@@noalloc]
   external rng_type : unit -> int  = "caml_cpu_rng_type" [@@noalloc]
-  external detect : unit -> unit = "caml_entropy_detect"
-
-  let () = detect ()
 
   let cpu_rng =
     match rng_type () with

--- a/mirage-crypto.opam
+++ b/mirage-crypto.opam
@@ -17,7 +17,6 @@ depends: [
   "ocaml" {>= "4.08.0"}
   "dune" {>= "1.7"}
   "dune-configurator" {>= "2.0.0"}
-  "cpuid" {build}
   "ounit" {with-test}
   "cstruct" {>="3.2.0"}
 ]

--- a/src/cipher_block.ml
+++ b/src/cipher_block.ml
@@ -451,6 +451,7 @@ end
 
 let accelerated =
   let flags =
+    (match Native.misc_mode () with 1 -> [`XOR] | _ -> []) @
     (match Native.AES.mode () with 1 -> [`AES] | _ -> []) @
     (match Native.GHASH.mode () with 1 -> [`GHASH] | _ -> []) in
-  match flags with [] -> [] | _ -> `XOR :: flags
+  flags

--- a/src/dune
+++ b/src/dune
@@ -3,7 +3,7 @@
   (public_name mirage-crypto)
   (libraries cstruct)
   (private_modules ccm cipher_block cipher_stream hash native uncommon)
-  (c_names misc
+  (c_names misc misc_sse
            md5 sha1 sha256 sha512 hash_stubs
            aes_generic aes_aesni ghash_generic ghash_pclmul
            des_generic

--- a/src/dune
+++ b/src/dune
@@ -1,7 +1,7 @@
 (library
   (name mirage_crypto)
   (public_name mirage-crypto)
-  (libraries cstruct)
+  (libraries cstruct cpuid)
   (private_modules ccm cipher_block cipher_stream hash native uncommon)
   (c_names misc misc_sse
            md5 sha1 sha256 sha512 hash_stubs

--- a/src/dune
+++ b/src/dune
@@ -1,13 +1,13 @@
 (library
   (name mirage_crypto)
   (public_name mirage-crypto)
-  (libraries cstruct cpuid)
+  (libraries cstruct)
   (private_modules ccm cipher_block cipher_stream hash native uncommon)
   (c_names misc misc_sse
            md5 sha1 sha256 sha512 hash_stubs
            aes_generic aes_aesni ghash_generic ghash_pclmul
            des_generic
-           entropy_cpu_stubs)
+           entropy_cpu_stubs detect_cpu_features)
   (c_flags (:standard) (:include cflags.sexp)))
 
 (include_subdirs unqualified)

--- a/src/dune
+++ b/src/dune
@@ -13,5 +13,4 @@
 (include_subdirs unqualified)
 
 (rule
-  (deps (env_var MIRAGE_CRYPTO_ACCELERATE))
   (action (with-stdout-to cflags.sexp (run ../config/cfg.exe))))

--- a/src/dune
+++ b/src/dune
@@ -3,11 +3,12 @@
   (public_name mirage-crypto)
   (libraries cstruct)
   (private_modules ccm cipher_block cipher_stream hash native uncommon)
-  (c_names misc misc_sse
+  (c_names detect_cpu_features
+           misc misc_sse
            md5 sha1 sha256 sha512 hash_stubs
            aes_generic aes_aesni ghash_generic ghash_pclmul
            des_generic
-           entropy_cpu_stubs detect_cpu_features)
+           entropy_cpu_stubs)
   (c_flags (:standard) (:include cflags.sexp)))
 
 (include_subdirs unqualified)

--- a/src/native.ml
+++ b/src/native.ml
@@ -92,6 +92,8 @@ external blit : buffer -> off -> buffer -> off -> size -> unit = "caml_blit_bigs
 external misc_mode : unit -> int = "mc_misc_mode" [@@noalloc]
 
 external _detect_cpu_features : unit -> unit = "mc_detect_cpu_features" [@@noalloc]
+external _detect_entropy : unit -> unit = "caml_entropy_detect"
 
 let () =
-  _detect_cpu_features ()
+  _detect_cpu_features ();
+  _detect_entropy ()

--- a/src/native.ml
+++ b/src/native.ml
@@ -91,11 +91,7 @@ external blit : buffer -> off -> buffer -> off -> size -> unit = "caml_blit_bigs
 
 external misc_mode : unit -> int = "mc_misc_mode" [@@noalloc]
 
-external _set_aesni_supported : bool -> unit = "mc_aesni_set_supported" [@@noalloc]
-external _set_pclmul_supported : bool -> unit = "mc_pclmul_set_supported" [@@noalloc]
-external _set_sse_supported : bool -> unit = "mc_sse_set_supported" [@@noalloc]
+external _detect_cpu_features : unit -> unit = "mc_detect_cpu_features" [@@noalloc]
 
 let () =
-  if Cpuid.supports [`SSSE3] = Ok true then _set_sse_supported true;
-  if Cpuid.supports [`AES] = Ok true then _set_aesni_supported true;
-  if Cpuid.supports [`PCLMULQDQ] = Ok true then _set_pclmul_supported true
+  _detect_cpu_features ()

--- a/src/native.ml
+++ b/src/native.ml
@@ -88,3 +88,12 @@ external count16be  : bytes -> buffer -> off -> blocks:size -> unit = "mc_count_
 external count16be4 : bytes -> buffer -> off -> blocks:size -> unit = "mc_count_16_be_4" [@@noalloc]
 
 external blit : buffer -> off -> buffer -> off -> size -> unit = "caml_blit_bigstring_to_bigstring" [@@noalloc]
+
+external _set_aesni_supported : bool -> unit = "mc_aesni_set_supported" [@@noalloc]
+external _set_pclmul_supported : bool -> unit = "mc_pclmul_set_supported" [@@noalloc]
+external _set_sse_supported : bool -> unit = "mc_sse_set_supported" [@@noalloc]
+
+let () =
+  if Cpuid.supports [`SSSE3] = Ok true then _set_sse_supported true;
+  if Cpuid.supports [`AES] = Ok true then _set_aesni_supported true;
+  if Cpuid.supports [`PCLMULQDQ] = Ok true then _set_pclmul_supported true

--- a/src/native.ml
+++ b/src/native.ml
@@ -89,6 +89,8 @@ external count16be4 : bytes -> buffer -> off -> blocks:size -> unit = "mc_count_
 
 external blit : buffer -> off -> buffer -> off -> size -> unit = "caml_blit_bigstring_to_bigstring" [@@noalloc]
 
+external misc_mode : unit -> int = "mc_misc_mode" [@@noalloc]
+
 external _set_aesni_supported : bool -> unit = "mc_aesni_set_supported" [@@noalloc]
 external _set_pclmul_supported : bool -> unit = "mc_pclmul_set_supported" [@@noalloc]
 external _set_sse_supported : bool -> unit = "mc_sse_set_supported" [@@noalloc]

--- a/src/native/aes_aesni.c
+++ b/src/native/aes_aesni.c
@@ -9,7 +9,7 @@
  */
 
 #include "mirage_crypto.h"
-#if defined (__mc_AES_NI__)
+#if defined (__mc_ACCELERATE__)
 
 /* xmm: [3, 2, 1, 0] */
 #define _S_3333 0xff
@@ -23,7 +23,7 @@
  *
  * XXX Get rid of the correction here.
  */
-int _mc_aesni_rk_size (uint8_t rounds) {
+static int _mc_aesni_rk_size (uint8_t rounds) {
   return (rounds + 1) * 16 + 15;
 }
 
@@ -336,52 +336,69 @@ static inline void _mc_aesni_dec_blocks (const uint8_t *src, uint8_t *dst, const
   __blocked_loop (_mc_aesni_dec, _mc_aesni_dec8, src, dst, rk, rounds, blocks);
 }
 
+#endif /* __mc_ACCELERATE__ */
 
 CAMLprim value
 mc_aes_rk_size (value rounds) {
-  return Val_int (_mc_aesni_rk_size (Int_val (rounds)));
+  value s;
+  _mc_switch_accel(
+    s = mc_aes_rk_size_generic(rounds),
+    s = Val_int (_mc_aesni_rk_size (Int_val (rounds))))
+  return s;
 }
 
 CAMLprim value
 mc_aes_derive_e_key (value key, value off1, value rk, value rounds) {
-  _mc_aesni_derive_e_key (_ba_uint8_off (key, off1),
-                          _ba_uint8 (rk),
-                          Int_val (rounds));
+  _mc_switch_accel(
+    mc_aes_derive_e_key_generic(key, off1, rk, rounds),
+    _mc_aesni_derive_e_key (_ba_uint8_off (key, off1),
+                            _ba_uint8 (rk),
+                            Int_val (rounds)))
   return Val_unit;
 }
 
 CAMLprim value
 mc_aes_derive_d_key (value key, value off1, value kr, value rounds, value rk) {
-  _mc_aesni_derive_d_key (_ba_uint8_off (key, off1),
-                          _ba_uint8 (kr),
-                          Int_val (rounds),
-                          Is_block(rk) ? _ba_uint8(Field(rk, 0)) : 0);
+  _mc_switch_accel(
+    mc_aes_derive_d_key_generic(key, off1, kr, rounds, rk),
+    _mc_aesni_derive_d_key (_ba_uint8_off (key, off1),
+                            _ba_uint8 (kr),
+                            Int_val (rounds),
+                            Is_block(rk) ? _ba_uint8(Field(rk, 0)) : 0))
   return Val_unit;
 }
 
 CAMLprim value
 mc_aes_enc (value src, value off1, value dst, value off2, value rk, value rounds, value blocks) {
-  _mc_aesni_enc_blocks ( _ba_uint8_off (src, off1),
-                         _ba_uint8_off (dst, off2),
-                         _ba_uint8 (rk),
-                         Int_val (rounds),
-                         Int_val (blocks) );
+  _mc_switch_accel(
+    mc_aes_enc_generic(src, off1, dst, off2, rk, rounds, blocks),
+    _mc_aesni_enc_blocks ( _ba_uint8_off (src, off1),
+                           _ba_uint8_off (dst, off2),
+                           _ba_uint8 (rk),
+                           Int_val (rounds),
+                           Int_val (blocks) ))
   return Val_unit;
 }
 
 CAMLprim value
 mc_aes_dec (value src, value off1, value dst, value off2, value rk, value rounds, value blocks) {
-  _mc_aesni_dec_blocks ( _ba_uint8_off (src, off1),
-                         _ba_uint8_off (dst, off2),
-                         _ba_uint8 (rk),
-                         Int_val (rounds),
-                         Int_val (blocks) );
+  _mc_switch_accel(
+    mc_aes_dec_generic(src, off1, dst, off2, rk, rounds, blocks),
+    _mc_aesni_dec_blocks ( _ba_uint8_off (src, off1),
+                           _ba_uint8_off (dst, off2),
+                           _ba_uint8 (rk),
+                           Int_val (rounds),
+                           Int_val (blocks) ))
   return Val_unit;
 }
 
-CAMLprim value mc_aes_mode (__unit ()) { return Val_int (1); }
+CAMLprim value mc_aes_mode (__unit ()) {
+  value enabled = 0;
+  _mc_switch_accel(
+    enabled = 0,
+    enabled = 1)
+  return Val_int (enabled);
+}
 
 __define_bc_7 (mc_aes_enc)
 __define_bc_7 (mc_aes_dec)
-
-#endif /* __mc_AES_NI__ */

--- a/src/native/aes_aesni.c
+++ b/src/native/aes_aesni.c
@@ -338,18 +338,10 @@ static inline void _mc_aesni_dec_blocks (const uint8_t *src, uint8_t *dst, const
 
 #endif /* __mc_ACCELERATE__ */
 
-static int _aesni_supported = 0;
-
-CAMLprim value
-mc_aesni_set_supported (value s) {
-  _aesni_supported = Bool_val(s);
-  return Val_unit;
-}
-
 CAMLprim value
 mc_aes_rk_size (value rounds) {
   value s;
-  _mc_switch_accel(_aesni_supported,
+  _mc_switch_accel(aesni,
     s = mc_aes_rk_size_generic(rounds),
     s = Val_int (_mc_aesni_rk_size (Int_val (rounds))))
   return s;
@@ -357,7 +349,7 @@ mc_aes_rk_size (value rounds) {
 
 CAMLprim value
 mc_aes_derive_e_key (value key, value off1, value rk, value rounds) {
-  _mc_switch_accel(_aesni_supported,
+  _mc_switch_accel(aesni,
     mc_aes_derive_e_key_generic(key, off1, rk, rounds),
     _mc_aesni_derive_e_key (_ba_uint8_off (key, off1),
                             _ba_uint8 (rk),
@@ -367,7 +359,7 @@ mc_aes_derive_e_key (value key, value off1, value rk, value rounds) {
 
 CAMLprim value
 mc_aes_derive_d_key (value key, value off1, value kr, value rounds, value rk) {
-  _mc_switch_accel(_aesni_supported,
+  _mc_switch_accel(aesni,
     mc_aes_derive_d_key_generic(key, off1, kr, rounds, rk),
     _mc_aesni_derive_d_key (_ba_uint8_off (key, off1),
                             _ba_uint8 (kr),
@@ -378,7 +370,7 @@ mc_aes_derive_d_key (value key, value off1, value kr, value rounds, value rk) {
 
 CAMLprim value
 mc_aes_enc (value src, value off1, value dst, value off2, value rk, value rounds, value blocks) {
-  _mc_switch_accel(_aesni_supported,
+  _mc_switch_accel(aesni,
     mc_aes_enc_generic(src, off1, dst, off2, rk, rounds, blocks),
     _mc_aesni_enc_blocks ( _ba_uint8_off (src, off1),
                            _ba_uint8_off (dst, off2),
@@ -390,7 +382,7 @@ mc_aes_enc (value src, value off1, value dst, value off2, value rk, value rounds
 
 CAMLprim value
 mc_aes_dec (value src, value off1, value dst, value off2, value rk, value rounds, value blocks) {
-  _mc_switch_accel(_aesni_supported,
+  _mc_switch_accel(aesni,
     mc_aes_dec_generic(src, off1, dst, off2, rk, rounds, blocks),
     _mc_aesni_dec_blocks ( _ba_uint8_off (src, off1),
                            _ba_uint8_off (dst, off2),
@@ -402,7 +394,7 @@ mc_aes_dec (value src, value off1, value dst, value off2, value rk, value rounds
 
 CAMLprim value mc_aes_mode (__unit ()) {
   value enabled = 0;
-  _mc_switch_accel(_aesni_supported,
+  _mc_switch_accel(aesni,
     enabled = 0,
     enabled = 1)
   return Val_int (enabled);

--- a/src/native/aes_aesni.c
+++ b/src/native/aes_aesni.c
@@ -338,10 +338,18 @@ static inline void _mc_aesni_dec_blocks (const uint8_t *src, uint8_t *dst, const
 
 #endif /* __mc_ACCELERATE__ */
 
+static int _aesni_supported = 0;
+
+CAMLprim value
+mc_aesni_set_supported (value s) {
+  _aesni_supported = Bool_val(s);
+  return Val_unit;
+}
+
 CAMLprim value
 mc_aes_rk_size (value rounds) {
   value s;
-  _mc_switch_accel(
+  _mc_switch_accel(_aesni_supported,
     s = mc_aes_rk_size_generic(rounds),
     s = Val_int (_mc_aesni_rk_size (Int_val (rounds))))
   return s;
@@ -349,7 +357,7 @@ mc_aes_rk_size (value rounds) {
 
 CAMLprim value
 mc_aes_derive_e_key (value key, value off1, value rk, value rounds) {
-  _mc_switch_accel(
+  _mc_switch_accel(_aesni_supported,
     mc_aes_derive_e_key_generic(key, off1, rk, rounds),
     _mc_aesni_derive_e_key (_ba_uint8_off (key, off1),
                             _ba_uint8 (rk),
@@ -359,7 +367,7 @@ mc_aes_derive_e_key (value key, value off1, value rk, value rounds) {
 
 CAMLprim value
 mc_aes_derive_d_key (value key, value off1, value kr, value rounds, value rk) {
-  _mc_switch_accel(
+  _mc_switch_accel(_aesni_supported,
     mc_aes_derive_d_key_generic(key, off1, kr, rounds, rk),
     _mc_aesni_derive_d_key (_ba_uint8_off (key, off1),
                             _ba_uint8 (kr),
@@ -370,7 +378,7 @@ mc_aes_derive_d_key (value key, value off1, value kr, value rounds, value rk) {
 
 CAMLprim value
 mc_aes_enc (value src, value off1, value dst, value off2, value rk, value rounds, value blocks) {
-  _mc_switch_accel(
+  _mc_switch_accel(_aesni_supported,
     mc_aes_enc_generic(src, off1, dst, off2, rk, rounds, blocks),
     _mc_aesni_enc_blocks ( _ba_uint8_off (src, off1),
                            _ba_uint8_off (dst, off2),
@@ -382,7 +390,7 @@ mc_aes_enc (value src, value off1, value dst, value off2, value rk, value rounds
 
 CAMLprim value
 mc_aes_dec (value src, value off1, value dst, value off2, value rk, value rounds, value blocks) {
-  _mc_switch_accel(
+  _mc_switch_accel(_aesni_supported,
     mc_aes_dec_generic(src, off1, dst, off2, rk, rounds, blocks),
     _mc_aesni_dec_blocks ( _ba_uint8_off (src, off1),
                            _ba_uint8_off (dst, off2),
@@ -394,7 +402,7 @@ mc_aes_dec (value src, value off1, value dst, value off2, value rk, value rounds
 
 CAMLprim value mc_aes_mode (__unit ()) {
   value enabled = 0;
-  _mc_switch_accel(
+  _mc_switch_accel(_aesni_supported,
     enabled = 0,
     enabled = 1)
   return Val_int (enabled);

--- a/src/native/aes_generic.c
+++ b/src/native/aes_generic.c
@@ -6,8 +6,6 @@
 
 #include "mirage_crypto.h"
 
-#if defined (__mc_AES_GENERIC__)
-
 #define KEYLENGTH(keybits) ((keybits)/8)
 #define RKLENGTH(keybits)  ((keybits)/8+28)
 #define NROUNDS(keybits)   ((keybits)/32+6)
@@ -1229,12 +1227,12 @@ static inline void _mc_aes_dec_blocks (const uint8_t *src, uint8_t *dst, const u
 }
 
 CAMLprim value
-mc_aes_rk_size (value rounds) {
+mc_aes_rk_size_generic (value rounds) {
   return Val_int (RKLENGTH (keybits_of_r (Int_val (rounds))) * sizeof(uint32_t));
 }
 
 CAMLprim value
-mc_aes_derive_e_key (value key, value off1, value rk, value rounds) {
+mc_aes_derive_e_key_generic (value key, value off1, value rk, value rounds) {
   mc_rijndaelSetupEncrypt (_ba_uint32 (rk),
                            _ba_uint8_off (key, off1),
                            keybits_of_r (Int_val (rounds)));
@@ -1242,7 +1240,7 @@ mc_aes_derive_e_key (value key, value off1, value rk, value rounds) {
 }
 
 CAMLprim value
-mc_aes_derive_d_key (value key, value off1, value kr, value rounds, value __unused (rk)) {
+mc_aes_derive_d_key_generic (value key, value off1, value kr, value rounds, value __unused (rk)) {
   mc_rijndaelSetupDecrypt (_ba_uint32 (kr),
                            _ba_uint8_off (key, off1),
                            keybits_of_r (Int_val (rounds)));
@@ -1250,7 +1248,7 @@ mc_aes_derive_d_key (value key, value off1, value kr, value rounds, value __unus
 }
 
 CAMLprim value
-mc_aes_enc (value src, value off1, value dst, value off2, value rk, value rounds, value blocks) {
+mc_aes_enc_generic (value src, value off1, value dst, value off2, value rk, value rounds, value blocks) {
   _mc_aes_enc_blocks ( _ba_uint8_off (src, off1),
                        _ba_uint8_off (dst, off2),
                        _ba_uint32 (rk),
@@ -1260,7 +1258,7 @@ mc_aes_enc (value src, value off1, value dst, value off2, value rk, value rounds
 }
 
 CAMLprim value
-mc_aes_dec (value src, value off1, value dst, value off2, value rk, value rounds, value blocks) {
+mc_aes_dec_generic (value src, value off1, value dst, value off2, value rk, value rounds, value blocks) {
   _mc_aes_dec_blocks ( _ba_uint8_off (src, off1),
                        _ba_uint8_off (dst, off2),
                        _ba_uint32 (rk),
@@ -1268,10 +1266,3 @@ mc_aes_dec (value src, value off1, value dst, value off2, value rk, value rounds
                        Int_val (blocks) );
   return Val_unit;
 }
-
-CAMLprim value mc_aes_mode (__unit ()) { return Val_int (0); }
-
-__define_bc_7 (mc_aes_enc)
-__define_bc_7 (mc_aes_dec)
-
-#endif /* __mc_AES_GENERIC__ */

--- a/src/native/detect_cpu_features.c
+++ b/src/native/detect_cpu_features.c
@@ -1,6 +1,6 @@
 #include "mirage_crypto.h"
 
-#if defined (__i386__) || defined (__x86_64__)
+#if defined (__i386__) || defined (__x86_64__) || defined (__mc_ACCELERATE__)
 
 #include <cpuid.h>
 

--- a/src/native/detect_cpu_features.c
+++ b/src/native/detect_cpu_features.c
@@ -1,0 +1,32 @@
+#include "mirage_crypto.h"
+
+#ifdef __mc_ACCELERATE__
+
+#include <cpuid.h>
+
+struct _mc_cpu_features mc_detected_cpu_features = { 0 };
+
+CAMLprim value
+mc_detect_cpu_features (__unit ()) {
+  unsigned int eax = 0, ebx = 0, ecx = 0, edx = 0;
+
+  if (__get_cpuid(1, &eax, &ebx, &ecx, &edx))
+  {
+    if (ecx & bit_PCLMUL)
+      mc_detected_cpu_features.pclmul = 1;
+    if (ecx & bit_SSSE3)
+      mc_detected_cpu_features.ssse3 = 1;
+    if (ecx & bit_AES)
+      mc_detected_cpu_features.aesni = 1;
+  }
+  return Val_unit;
+}
+
+#else /* __mc_ACCELERATE__ */
+
+CAMLprim value
+mc_detect_cpu_features (__unit ()) {
+  return Val_unit;
+}
+
+#endif /* __mc_ACCELERATE__ */

--- a/src/native/detect_cpu_features.c
+++ b/src/native/detect_cpu_features.c
@@ -1,6 +1,6 @@
 #include "mirage_crypto.h"
 
-#ifdef __mc_ACCELERATE__
+#if defined (__i386__) || defined (__x86_64__)
 
 #include <cpuid.h>
 
@@ -10,23 +10,30 @@ CAMLprim value
 mc_detect_cpu_features (__unit ()) {
   unsigned int eax = 0, ebx = 0, ecx = 0, edx = 0;
 
-  if (__get_cpuid(1, &eax, &ebx, &ecx, &edx))
-  {
+  if (__get_cpuid(1, &eax, &ebx, &ecx, &edx)) {
     if (ecx & bit_PCLMUL)
       mc_detected_cpu_features.pclmul = 1;
     if (ecx & bit_SSSE3)
       mc_detected_cpu_features.ssse3 = 1;
     if (ecx & bit_AES)
       mc_detected_cpu_features.aesni = 1;
+    if (ecx & bit_RDRND)
+      mc_detected_cpu_features.rdrand = 1;
   }
+
+  if (__get_cpuid_count(7, 0, &eax, &ebx, &ecx, &edx)) {
+    if (ebx & bit_RDSEED)
+      mc_detected_cpu_features.rdseed = 1;
+  }
+
   return Val_unit;
 }
 
-#else /* __mc_ACCELERATE__ */
+#else /* i386 || x86_64 */
 
 CAMLprim value
 mc_detect_cpu_features (__unit ()) {
   return Val_unit;
 }
 
-#endif /* __mc_ACCELERATE__ */
+#endif /* i386 || x86_64 */

--- a/src/native/detect_cpu_features.c
+++ b/src/native/detect_cpu_features.c
@@ -8,20 +8,24 @@ struct _mc_cpu_features mc_detected_cpu_features = { 0 };
 
 CAMLprim value
 mc_detect_cpu_features (__unit ()) {
-  unsigned int eax = 0, ebx = 0, ecx = 0, edx = 0;
+  unsigned int sig = 0, eax = 0, ebx = 0, ecx = 0, edx = 0;
 
-  if (__get_cpuid(1, &eax, &ebx, &ecx, &edx)) {
-    if (ecx & bit_PCLMUL)
-      mc_detected_cpu_features.pclmul = 1;
-    if (ecx & bit_SSSE3)
-      mc_detected_cpu_features.ssse3 = 1;
-    if (ecx & bit_AES)
-      mc_detected_cpu_features.aesni = 1;
-    if (ecx & bit_RDRND)
-      mc_detected_cpu_features.rdrand = 1;
-  }
+  int max = __get_cpuid_max(0, &sig);
 
-  if (__get_cpuid_count(7, 0, &eax, &ebx, &ecx, &edx)) {
+  if (max < 1) return Val_unit;
+
+  __cpuid(1, eax, ebx, ecx, edx);
+  if (ecx & bit_PCLMUL)
+    mc_detected_cpu_features.pclmul = 1;
+  if (ecx & bit_SSSE3)
+    mc_detected_cpu_features.ssse3 = 1;
+  if (ecx & bit_AES)
+    mc_detected_cpu_features.aesni = 1;
+  if (ecx & bit_RDRND)
+    mc_detected_cpu_features.rdrand = 1;
+
+  if (max > 7) {
+    __cpuid_count(7, 0, eax, ebx, ecx, edx);
     if (ebx & bit_RDSEED)
       mc_detected_cpu_features.rdseed = 1;
   }

--- a/src/native/detect_cpu_features.c
+++ b/src/native/detect_cpu_features.c
@@ -1,6 +1,6 @@
 #include "mirage_crypto.h"
 
-#if defined (__i386__) || defined (__x86_64__) || defined (__mc_ACCELERATE__)
+#ifdef __mc_detect_features__
 
 #include <cpuid.h>
 
@@ -33,11 +33,11 @@ mc_detect_cpu_features (__unit ()) {
   return Val_unit;
 }
 
-#else /* i386 || x86_64 */
+#else /* __mc_detect_features__ */
 
 CAMLprim value
 mc_detect_cpu_features (__unit ()) {
   return Val_unit;
 }
 
-#endif /* i386 || x86_64 */
+#endif /* __mc_detect_features__ */

--- a/src/native/entropy_cpu_stubs.c
+++ b/src/native/entropy_cpu_stubs.c
@@ -7,8 +7,6 @@
 #include "mirage_crypto.h"
 
 #if defined (__i386__) || defined (__x86_64__)
-#define __x86__
-
 #include <x86intrin.h>
 
 #if defined (__x86_64__)
@@ -56,7 +54,7 @@ static enum cpu_rng_t __cpu_rng = RNG_NONE;
 #define RETRIES 10
 
 static void detect () {
-#if defined (__x86__)
+#ifdef __mc_ENTROPY__
   random_t r = 0;
 
   if (mc_detected_cpu_features.rdrand)
@@ -80,7 +78,7 @@ static void detect () {
 }
 
 CAMLprim value caml_cycle_counter (value __unused(unit)) {
-#if defined (__x86__)
+#if defined (__i386__) || defined (__x86_64__)
   return Val_long (__rdtsc ());
 #elif defined (__arm__) || defined (__aarch64__)
   return Val_long (read_virtual_count ());
@@ -90,7 +88,7 @@ CAMLprim value caml_cycle_counter (value __unused(unit)) {
 }
 
 CAMLprim value caml_cpu_checked_random (value __unused(unit)) {
-#if defined (__x86__)
+#ifdef __mc_ENTROPY__
   random_t r = 0;
   int ok = 0;
   int i = RETRIES;
@@ -112,7 +110,7 @@ CAMLprim value caml_cpu_checked_random (value __unused(unit)) {
 }
 
 CAMLprim value caml_cpu_unchecked_random (value __unused(unit)) {
-#if defined (__x86__)
+#ifdef __mc_ENTROPY__
   random_t r = 0;
   /* rdrand/rdseed may fail (and return CR = 0) if insufficient entropy is
      available (or the hardware DRNG is in the middle of reseeding).

--- a/src/native/entropy_cpu_stubs.c
+++ b/src/native/entropy_cpu_stubs.c
@@ -10,12 +10,6 @@
 #define __x86__
 
 #include <x86intrin.h>
-#include <cpuid.h>
-
-/* because clang... */
-#if !defined(bit_RDSEED)
-#define bit_RDSEED 0x00040000
-#endif
 
 #if defined (__x86_64__)
 #define random_t unsigned long long
@@ -31,7 +25,6 @@
 #endif /* __i386__ || __x86_64__ */
 
 #if defined (__arm__)
-
 /* Replace with `read_virtual_count` from MiniOS when that symbol
  * gets exported. */
 static inline uint32_t read_virtual_count () {
@@ -40,6 +33,7 @@ static inline uint32_t read_virtual_count () {
   return c_lo;
 }
 #endif /* arm */
+
 #if defined (__aarch64__)
 #define	isb()		__asm __volatile("isb" : : : "memory")
 static inline uint64_t read_virtual_count(void)
@@ -63,35 +57,25 @@ static enum cpu_rng_t __cpu_rng = RNG_NONE;
 
 static void detect () {
 #if defined (__x86__)
-
-  unsigned int sig, eax, ebx, ecx, edx;
-  int max = __get_cpuid_max (0, &sig);
   random_t r = 0;
 
-  if (max < 1) return;
+  if (mc_detected_cpu_features.rdrand)
+    /* AMD Ryzen 3000 bug where RDRAND always returns -1
+       https://arstechnica.com/gadgets/2019/10/how-a-months-old-amd-microcode-bug-destroyed-my-weekend/ */
+    for (int i = 0; i < RETRIES; i++)
+      if (_rdrand_step(&r) == 1 && r != (random_t) (-1)) {
+        __cpu_rng = RNG_RDRAND;
+        break;
+      }
 
-  if (sig == signature_INTEL_ebx || sig == signature_AMD_ebx) {
-    __cpuid (1, eax, ebx, ecx, edx);
-    if (ecx & bit_RDRND)
-      /* AMD Ryzen 3000 bug where RDRAND always returns -1
-         https://arstechnica.com/gadgets/2019/10/how-a-months-old-amd-microcode-bug-destroyed-my-weekend/ */
-      for (int i = 0; i < RETRIES; i++)
-        if (_rdrand_step(&r) == 1 && r != (random_t) (-1)) {
-          __cpu_rng = RNG_RDRAND;
-          break;
-        }
-    if (max > 7) {
-      __cpuid_count (7, 0, eax, ebx, ecx, edx);
-      if (ebx & bit_RDSEED)
-        /* RDSEED could return -1 as well, thus we test it here as well
-           https://www.reddit.com/r/Amd/comments/cmza34/agesa_1003_abb_fixes_rdrandrdseed/ */
-        for (int i = 0; i < RETRIES; i++)
-          if (_rdseed_step(&r) == 1 && r != (random_t) (-1)) {
-            __cpu_rng = RNG_RDSEED;
-            break;
-          }
-    }
-  }
+  if (mc_detected_cpu_features.rdseed)
+    /* RDSEED could return -1, thus we test it here
+       https://www.reddit.com/r/Amd/comments/cmza34/agesa_1003_abb_fixes_rdrandrdseed/ */
+    for (int i = 0; i < RETRIES; i++)
+      if (_rdseed_step(&r) == 1 && r != (random_t) (-1)) {
+        __cpu_rng = RNG_RDSEED;
+        break;
+      }
 #endif
 }
 

--- a/src/native/ghash_generic.c
+++ b/src/native/ghash_generic.c
@@ -14,8 +14,6 @@
 #define __MC_GHASH_LARGE_TABLES
 
 #include "mirage_crypto.h"
-#if !defined (__mc_PCLMUL__)
-
 #include <string.h>
 
 #define __set_uint128_t(w1, w0) (((__uint128_t) w1 << 64) | w0)
@@ -87,22 +85,18 @@ static inline void __ghash (__uint128_t m[__t_size], uint64_t hash[2], const uin
   __store_128_t (hash, acc);
 }
 
-CAMLprim value mc_ghash_key_size (__unit ()) {
+CAMLprim value mc_ghash_key_size_generic (__unit ()) {
   return Val_int (sizeof (__uint128_t) * __t_size);
 }
 
-CAMLprim value mc_ghash_init_key (value key, value off, value m) {
+CAMLprim value mc_ghash_init_key_generic (value key, value off, value m) {
   __derive ((uint64_t *) _ba_uint8_off (key, off), (__uint128_t *) Bp_val (m));
   return Val_unit;
 }
 
 CAMLprim value
-mc_ghash (value m, value hash, value src, value off, value len) {
+mc_ghash_generic (value m, value hash, value src, value off, value len) {
   __ghash ((__uint128_t *) Bp_val (m), (uint64_t *) Bp_val (hash),
            _ba_uint8_off (src, off), Int_val (len) );
   return Val_unit;
 }
-
-CAMLprim value mc_ghash_mode (__unit ()) { return Val_int (0); }
-
-#endif /* __mc_PCLMUL__ */

--- a/src/native/ghash_pclmul.c
+++ b/src/native/ghash_pclmul.c
@@ -21,7 +21,7 @@
 #define __MC_GHASH_AGGREGATED_REDUCE
 
 #include "mirage_crypto.h"
-#if defined (__mc_PCLMUL__)
+#ifdef __mc_ACCELERATE__
 
 #include <string.h>
 
@@ -186,20 +186,36 @@ static inline void __ghash (__m128i *m, __m128i hash[1], const __m128i *src, siz
   _mm_storeu_si128 (hash, __repr_xform (acc));
 }
 
-CAMLprim value mc_ghash_key_size (__unit ()) { return Val_int (__keys * 16); }
+#endif /* __mc_ACCELERATE__ */
+
+CAMLprim value mc_ghash_key_size (__unit ()) {
+  value s;
+  _mc_switch_accel(
+    s = mc_ghash_key_size_generic(Val_unit),
+    s = Val_int (__keys * 16))
+  return s;
+}
 
 CAMLprim value mc_ghash_init_key (value key, value off, value m) {
-  __derive ((__m128i *) _ba_uint8_off (key, off), (__m128i *) Bp_val (m));
+  _mc_switch_accel(
+    mc_ghash_init_key_generic(key, off, m),
+    __derive ((__m128i *) _ba_uint8_off (key, off), (__m128i *) Bp_val (m)))
   return Val_unit;
 }
 
 CAMLprim value
 mc_ghash (value k, value hash, value src, value off, value len) {
-  __ghash ( (__m128i *) Bp_val (k), (__m128i *) Bp_val (hash),
-            (__m128i *) _ba_uint8_off (src, off), Int_val (len) );
+  _mc_switch_accel(
+    mc_ghash_generic(k, hash, src, off, len),
+    __ghash ( (__m128i *) Bp_val (k), (__m128i *) Bp_val (hash),
+      (__m128i *) _ba_uint8_off (src, off), Int_val (len) ))
   return Val_unit;
 }
 
-CAMLprim value mc_ghash_mode (__unit ()) { return Val_int (1); }
-
-#endif /* __mc_PCLMUL__ */
+CAMLprim value mc_ghash_mode (__unit ()) {
+  value enabled = 0;
+  _mc_switch_accel(
+    enabled = 0,
+    enabled = 1)
+  return Val_int (enabled);
+}

--- a/src/native/ghash_pclmul.c
+++ b/src/native/ghash_pclmul.c
@@ -188,16 +188,24 @@ static inline void __ghash (__m128i *m, __m128i hash[1], const __m128i *src, siz
 
 #endif /* __mc_ACCELERATE__ */
 
+static int _pclmul_supported = 0;
+
+CAMLprim value
+mc_pclmul_set_supported (value s) {
+  _pclmul_supported = Bool_val(s);
+  return Val_unit;
+}
+
 CAMLprim value mc_ghash_key_size (__unit ()) {
   value s;
-  _mc_switch_accel(
+  _mc_switch_accel(_pclmul_supported,
     s = mc_ghash_key_size_generic(Val_unit),
     s = Val_int (__keys * 16))
   return s;
 }
 
 CAMLprim value mc_ghash_init_key (value key, value off, value m) {
-  _mc_switch_accel(
+  _mc_switch_accel(_pclmul_supported,
     mc_ghash_init_key_generic(key, off, m),
     __derive ((__m128i *) _ba_uint8_off (key, off), (__m128i *) Bp_val (m)))
   return Val_unit;
@@ -205,7 +213,7 @@ CAMLprim value mc_ghash_init_key (value key, value off, value m) {
 
 CAMLprim value
 mc_ghash (value k, value hash, value src, value off, value len) {
-  _mc_switch_accel(
+  _mc_switch_accel(_pclmul_supported,
     mc_ghash_generic(k, hash, src, off, len),
     __ghash ( (__m128i *) Bp_val (k), (__m128i *) Bp_val (hash),
       (__m128i *) _ba_uint8_off (src, off), Int_val (len) ))
@@ -214,7 +222,7 @@ mc_ghash (value k, value hash, value src, value off, value len) {
 
 CAMLprim value mc_ghash_mode (__unit ()) {
   value enabled = 0;
-  _mc_switch_accel(
+  _mc_switch_accel(_pclmul_supported,
     enabled = 0,
     enabled = 1)
   return Val_int (enabled);

--- a/src/native/ghash_pclmul.c
+++ b/src/native/ghash_pclmul.c
@@ -188,24 +188,16 @@ static inline void __ghash (__m128i *m, __m128i hash[1], const __m128i *src, siz
 
 #endif /* __mc_ACCELERATE__ */
 
-static int _pclmul_supported = 0;
-
-CAMLprim value
-mc_pclmul_set_supported (value s) {
-  _pclmul_supported = Bool_val(s);
-  return Val_unit;
-}
-
 CAMLprim value mc_ghash_key_size (__unit ()) {
   value s;
-  _mc_switch_accel(_pclmul_supported,
+  _mc_switch_accel(pclmul,
     s = mc_ghash_key_size_generic(Val_unit),
     s = Val_int (__keys * 16))
   return s;
 }
 
 CAMLprim value mc_ghash_init_key (value key, value off, value m) {
-  _mc_switch_accel(_pclmul_supported,
+  _mc_switch_accel(pclmul,
     mc_ghash_init_key_generic(key, off, m),
     __derive ((__m128i *) _ba_uint8_off (key, off), (__m128i *) Bp_val (m)))
   return Val_unit;
@@ -213,7 +205,7 @@ CAMLprim value mc_ghash_init_key (value key, value off, value m) {
 
 CAMLprim value
 mc_ghash (value k, value hash, value src, value off, value len) {
-  _mc_switch_accel(_pclmul_supported,
+  _mc_switch_accel(pclmul,
     mc_ghash_generic(k, hash, src, off, len),
     __ghash ( (__m128i *) Bp_val (k), (__m128i *) Bp_val (hash),
       (__m128i *) _ba_uint8_off (src, off), Int_val (len) ))
@@ -222,7 +214,7 @@ mc_ghash (value k, value hash, value src, value off, value len) {
 
 CAMLprim value mc_ghash_mode (__unit ()) {
   value enabled = 0;
-  _mc_switch_accel(_pclmul_supported,
+  _mc_switch_accel(pclmul,
     enabled = 0,
     enabled = 1)
   return Val_int (enabled);

--- a/src/native/mirage_crypto.h
+++ b/src/native/mirage_crypto.h
@@ -7,7 +7,7 @@
 #include <caml/mlvalues.h>
 #include <caml/bigarray.h>
 
-#if defined (__x86_64__)
+#ifdef ACCELERATE
 #include <x86intrin.h>
 #define __mc_ACCELERATE__
 #endif

--- a/src/native/mirage_crypto.h
+++ b/src/native/mirage_crypto.h
@@ -14,12 +14,13 @@
 
 #ifdef __mc_ACCELERATE__
 
-#define _mc_switch_accel(_GENERIC_CALL, ACCELERATED_CALL) \
-  ACCELERATED_CALL;
+#define _mc_switch_accel(SUPPORTED, GENERIC_CALL, ACCELERATED_CALL) \
+  if (!(SUPPORTED)) { GENERIC_CALL; } \
+  else { ACCELERATED_CALL; }
 
 #else /* __mc_ACCELERATE__ */
 
-#define _mc_switch_accel(GENERIC_CALL, _ACCELERATED_CALL) \
+#define _mc_switch_accel(_SUPPORTED, GENERIC_CALL, _ACCELERATED_CALL) \
   GENERIC_CALL;
 
 #endif /* __mc_ACCELERATE__ */

--- a/src/native/mirage_crypto.h
+++ b/src/native/mirage_crypto.h
@@ -12,16 +12,22 @@
 #define __mc_ACCELERATE__
 #endif
 
-#ifdef __mc_ACCELERATE__
+#if defined (__i386__) || defined (__x86_64__)
 
 struct _mc_cpu_features {
   int aesni;
   int pclmul;
   int ssse3;
+  int rdrand;
+  int rdseed;
 };
 
 /* Supported accelerations */
 extern struct _mc_cpu_features mc_detected_cpu_features;
+
+#endif /* __i386__ || __x86_64__ */
+
+#ifdef __mc_ACCELERATE__
 
 #define _mc_switch_accel(FEATURE, GENERIC_CALL, ACCELERATED_CALL) \
   if (!(mc_detected_cpu_features.FEATURE)) { GENERIC_CALL; } \

--- a/src/native/mirage_crypto.h
+++ b/src/native/mirage_crypto.h
@@ -9,21 +9,20 @@
 
 #if defined (__x86_64__) && defined (ACCELERATE)
 #include <x86intrin.h>
+#define __mc_ACCELERATE__
 #endif
 
-#if defined (__x86_64__) && defined (ACCELERATE) && defined (__SSSE3__)
-#define __mc_SSE__
-#endif
+#ifdef __mc_ACCELERATE__
 
-#if defined (__x86_64__) && defined (ACCELERATE) && defined (__AES__)
-#define __mc_AES_NI__
-#else
-#define __mc_AES_GENERIC__
-#endif
+#define _mc_switch_accel(_GENERIC_CALL, ACCELERATED_CALL) \
+  ACCELERATED_CALL;
 
-#if defined (__x86_64__) && defined (ACCELERATE) && defined (__PCLMUL__)
-#define __mc_PCLMUL__
-#endif
+#else /* __mc_ACCELERATE__ */
+
+#define _mc_switch_accel(GENERIC_CALL, _ACCELERATED_CALL) \
+  GENERIC_CALL;
+
+#endif /* __mc_ACCELERATE__ */
 
 #ifndef __unused
 #define __unused(x) x __attribute__((unused))
@@ -45,5 +44,34 @@
 
 #define __define_bc_7(f) \
   CAMLprim value f ## _bc (value *v, int __unused(c) ) { return f(v[0], v[1], v[2], v[3], v[4], v[5], v[6]); }
+
+/* Signature of generic functions */
+
+CAMLprim value mc_aes_rk_size_generic (value rounds);
+
+CAMLprim value
+mc_aes_derive_e_key_generic (value key, value off1, value rk, value rounds);
+
+CAMLprim value
+mc_aes_derive_d_key_generic (value key, value off1, value kr, value rounds, value __unused (rk));
+
+CAMLprim value
+mc_aes_enc_generic (value src, value off1, value dst, value off2, value rk, value rounds, value blocks);
+
+CAMLprim value
+mc_aes_dec_generic (value src, value off1, value dst, value off2, value rk, value rounds, value blocks);
+
+CAMLprim value mc_ghash_key_size_generic (__unit ());
+
+CAMLprim value mc_ghash_init_key_generic (value key, value off, value m);
+
+CAMLprim value
+mc_ghash_generic (value m, value hash, value src, value off, value len);
+
+CAMLprim value
+mc_xor_into_generic (value b1, value off1, value b2, value off2, value n);
+
+CAMLprim value
+mc_count_16_be_4_generic (value ctr, value dst, value off, value blocks);
 
 #endif /* H__MIRAGE_CRYPTO */

--- a/src/native/mirage_crypto.h
+++ b/src/native/mirage_crypto.h
@@ -7,7 +7,7 @@
 #include <caml/mlvalues.h>
 #include <caml/bigarray.h>
 
-#if defined (__x86_64__) && defined (ACCELERATE)
+#if defined (__x86_64__)
 #include <x86intrin.h>
 #define __mc_ACCELERATE__
 #endif

--- a/src/native/mirage_crypto.h
+++ b/src/native/mirage_crypto.h
@@ -10,9 +10,15 @@
 #ifdef ACCELERATE
 #include <x86intrin.h>
 #define __mc_ACCELERATE__
+#define __mc_detect_features__
 #endif
 
-#if defined (__i386__) || defined (__x86_64__)
+#ifdef ENTROPY
+#define __mc_ENTROPY__
+#define __mc_detect_features__
+#endif
+
+#ifdef __mc_detect_features__
 
 struct _mc_cpu_features {
   int aesni;
@@ -25,7 +31,7 @@ struct _mc_cpu_features {
 /* Supported accelerations */
 extern struct _mc_cpu_features mc_detected_cpu_features;
 
-#endif /* __i386__ || __x86_64__ */
+#endif /* __mc_detect_features__ */
 
 #ifdef __mc_ACCELERATE__
 

--- a/src/native/mirage_crypto.h
+++ b/src/native/mirage_crypto.h
@@ -14,13 +14,22 @@
 
 #ifdef __mc_ACCELERATE__
 
-#define _mc_switch_accel(SUPPORTED, GENERIC_CALL, ACCELERATED_CALL) \
-  if (!(SUPPORTED)) { GENERIC_CALL; } \
+struct _mc_cpu_features {
+  int aesni;
+  int pclmul;
+  int ssse3;
+};
+
+/* Supported accelerations */
+extern struct _mc_cpu_features mc_detected_cpu_features;
+
+#define _mc_switch_accel(FEATURE, GENERIC_CALL, ACCELERATED_CALL) \
+  if (!(mc_detected_cpu_features.FEATURE)) { GENERIC_CALL; } \
   else { ACCELERATED_CALL; }
 
 #else /* __mc_ACCELERATE__ */
 
-#define _mc_switch_accel(_SUPPORTED, GENERIC_CALL, _ACCELERATED_CALL) \
+#define _mc_switch_accel(_FEATURE, GENERIC_CALL, _ACCELERATED_CALL) \
   GENERIC_CALL;
 
 #endif /* __mc_ACCELERATE__ */

--- a/src/native/misc.c
+++ b/src/native/misc.c
@@ -1,16 +1,6 @@
 #include "mirage_crypto.h"
 
-
 static inline void xor_into (uint8_t *src, uint8_t *dst, size_t n) {
-
-#if defined (__mc_SSE__)
-  for (; n >= 16; n -= 16, src += 16, dst += 16)
-    _mm_storeu_si128 (
-        (__m128i*) dst,
-        _mm_xor_si128 (
-          _mm_loadu_si128 ((__m128i*) src),
-          _mm_loadu_si128 ((__m128i*) dst)));
-#endif
 
   for (; n >= 8; n -= 8, src += 8, dst += 8)
     *(uint64_t*) dst ^= *(uint64_t*) src;
@@ -46,15 +36,6 @@ static inline void _mc_count_16_be (uint64_t *init, uint64_t *dst, size_t blocks
 /* The GCM counter. Counts on the last 32 bits, ignoring carry. */
 static inline void _mc_count_16_be_4 (uint64_t *init, uint64_t *dst, size_t blocks) {
 
-#if defined (__mc_SSE__)
-  __m128i ctr, c1   = _mm_set_epi32 (1, 0, 0, 0),
-               mask = _mm_set_epi64x (0x0c0d0e0f0b0a0908, 0x0706050403020100);
-  ctr = _mm_shuffle_epi8 (_mm_loadu_si128 ((__m128i *) init), mask);
-  for (; blocks --; dst += 2) {
-    _mm_storeu_si128 ((__m128i *) dst, _mm_shuffle_epi8 (ctr, mask));
-    ctr = _mm_add_epi32 (ctr, c1);
-  }
-#else
   uint64_t qw1 = init[0];
   uint32_t dw3 = ((uint32_t*) init)[2],
            dw4 = be32_to_cpu (((uint32_t*) init)[3]);
@@ -63,12 +44,10 @@ static inline void _mc_count_16_be_4 (uint64_t *init, uint64_t *dst, size_t bloc
     ((uint32_t*) dst)[2] = dw3;
     ((uint32_t*) dst)[3] = cpu_to_be32 (dw4 ++);
   }
-#endif
-
 }
 
 CAMLprim value
-mc_xor_into (value b1, value off1, value b2, value off2, value n) {
+mc_xor_into_generic (value b1, value off1, value b2, value off2, value n) {
   xor_into (_ba_uint8_off (b1, off1), _ba_uint8_off (b2, off2), Int_val (n));
   return Val_unit;
 }
@@ -82,4 +61,4 @@ mc_xor_into (value b1, value off1, value b2, value off2, value n) {
 
 __export_counter (mc_count_8_be, _mc_count_8_be)
 __export_counter (mc_count_16_be, _mc_count_16_be)
-__export_counter (mc_count_16_be_4, _mc_count_16_be_4)
+__export_counter (mc_count_16_be_4_generic, _mc_count_16_be_4)

--- a/src/native/misc_sse.c
+++ b/src/native/misc_sse.c
@@ -1,0 +1,59 @@
+#include "mirage_crypto.h"
+
+#ifdef __mc_ACCELERATE__
+
+static inline void xor_into (uint8_t *src, uint8_t *dst, size_t n) {
+
+  for (; n >= 16; n -= 16, src += 16, dst += 16)
+    _mm_storeu_si128 (
+        (__m128i*) dst,
+        _mm_xor_si128 (
+          _mm_loadu_si128 ((__m128i*) src),
+          _mm_loadu_si128 ((__m128i*) dst)));
+
+  for (; n >= 8; n -= 8, src += 8, dst += 8)
+    *(uint64_t*) dst ^= *(uint64_t*) src;
+
+  for (; n --; ++ src, ++ dst) *dst = *src ^ *dst;
+}
+
+/* The GCM counter. Counts on the last 32 bits, ignoring carry. */
+static inline void _mc_count_16_be_4 (uint64_t *init, uint64_t *dst, size_t blocks) {
+
+  __m128i ctr, c1   = _mm_set_epi32 (1, 0, 0, 0),
+               mask = _mm_set_epi64x (0x0c0d0e0f0b0a0908, 0x0706050403020100);
+  ctr = _mm_shuffle_epi8 (_mm_loadu_si128 ((__m128i *) init), mask);
+  for (; blocks --; dst += 2) {
+    _mm_storeu_si128 ((__m128i *) dst, _mm_shuffle_epi8 (ctr, mask));
+    ctr = _mm_add_epi32 (ctr, c1);
+  }
+}
+
+#endif /* __mc_ACCELERATE__ */
+
+CAMLprim value
+mc_xor_into (value b1, value off1, value b2, value off2, value n) {
+  _mc_switch_accel(
+    mc_xor_into_generic(b1, off1, b2, off2, n),
+    xor_into (_ba_uint8_off (b1, off1), _ba_uint8_off (b2, off2), Int_val (n)))
+  return Val_unit;
+}
+
+#define __export_counter(name, f)                                        \
+  CAMLprim value name (value ctr, value dst, value off, value blocks) {  \
+    _mc_switch_accel(                                                    \
+      name##_generic (ctr, dst, off, blocks),                            \
+      f ( (uint64_t*) Bp_val (ctr),                                      \
+          (uint64_t*) _ba_uint8_off (dst, off), Long_val (blocks) ))     \
+    return Val_unit;                                                     \
+  }
+
+__export_counter(mc_count_16_be_4, _mc_count_16_be_4)
+
+CAMLprim value mc_misc_mode (__unit ()) {
+  value enabled = 0;
+  _mc_switch_accel(
+    enabled = 0,
+    enabled = 1)
+  return Val_int (enabled);
+}

--- a/src/native/misc_sse.c
+++ b/src/native/misc_sse.c
@@ -31,17 +31,9 @@ static inline void _mc_count_16_be_4 (uint64_t *init, uint64_t *dst, size_t bloc
 
 #endif /* __mc_ACCELERATE__ */
 
-static int _sse_supported = 0;
-
-CAMLprim value
-mc_sse_set_supported (value s) {
-  _sse_supported = Bool_val(s);
-  return Val_unit;
-}
-
 CAMLprim value
 mc_xor_into (value b1, value off1, value b2, value off2, value n) {
-  _mc_switch_accel(_sse_supported,
+  _mc_switch_accel(ssse3,
     mc_xor_into_generic(b1, off1, b2, off2, n),
     xor_into (_ba_uint8_off (b1, off1), _ba_uint8_off (b2, off2), Int_val (n)))
   return Val_unit;
@@ -49,7 +41,7 @@ mc_xor_into (value b1, value off1, value b2, value off2, value n) {
 
 #define __export_counter(name, f)                                        \
   CAMLprim value name (value ctr, value dst, value off, value blocks) {  \
-    _mc_switch_accel(_sse_supported,                                     \
+    _mc_switch_accel(ssse3,                                     \
       name##_generic (ctr, dst, off, blocks),                            \
       f ( (uint64_t*) Bp_val (ctr),                                      \
           (uint64_t*) _ba_uint8_off (dst, off), Long_val (blocks) ))     \
@@ -60,7 +52,7 @@ __export_counter(mc_count_16_be_4, _mc_count_16_be_4)
 
 CAMLprim value mc_misc_mode (__unit ()) {
   value enabled = 0;
-  _mc_switch_accel(_sse_supported,
+  _mc_switch_accel(ssse3,
     enabled = 0,
     enabled = 1)
   return Val_int (enabled);


### PR DESCRIPTION
Hi !

This PR adds runtime detection of CPU features.
Both accelerated and generic functions are built and linked. This is implemented with a global variable checked on every call.
The detection is done at initialization time using the library `cpuid`.

Running the all the benchmarks in `bench/` either shows no difference or a slight decrease in performances (consistent 1% on sha1, too much noise on others).

I first tried using modules ([on this branch](https://github.com/mirage/mirage-crypto/compare/master...Julow:runtime-cpuid)) and selecting the right function at the beginning.
This was slower because calls to external functions were no longer inlined (a closure and `caml_apply` indirections)

The cpuid library allocates (around 3Kb) data structures that are only needed once but not collected.

I didn't remove the `MIRAGE_CRYPTO_ACCELERATE` env variable, the acceleration is only enabled on `x86_64` systems so removing the variable would not remove any code.

Partially solves issue https://github.com/mirage/mirage-crypto/issues/45.
The RDRAND/RDSEED flags are still detected at build time but this may not be a problem for deployments as only architecture is checked, which is still in cross-compilation's scope.