### PR TITLE
in development mode, add -Werror to CFLAGS

### DIFF
--- a/rng/unix/dune
+++ b/rng/unix/dune
@@ -14,3 +14,6 @@
   (libraries mirage-crypto-rng unix)
   (c_names mc_getrandom_stubs)
   (c_library_flags (:include rng_c_flags.sexp)))
+
+(env
+  (dev (c_flags (-Werror))))

--- a/src/dune
+++ b/src/dune
@@ -11,6 +11,9 @@
            entropy_cpu_stubs)
   (c_flags (:standard) (:include cflags.sexp)))
 
+(env
+  (dev (c_flags (-Werror))))
+
 (include_subdirs unqualified)
 
 (rule


### PR DESCRIPTION
thanks to @samoht for the hint (I tested this locally, and a `dune build --verbose` showed me `-Werror`, a `dune build --profile=release --verbose` not -- I'm not sure whether it is correct, though)