### PR TITLE
Mirage_crypto_rng_lwt.initialize now returns unit instead of unit Lwt.t

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,8 +27,9 @@ jobs:
         run: |
           opam pin add -n mirage-crypto.dev .
           opam pin add -n mirage-crypto-rng.dev .
+          opam pin add -n mirage-crypto-rng-mirage.dev .
           opam pin add -n mirage-crypto-pk.dev .
-          opam depext -y mirage-crypto mirage-crypto-rng mirage-crypto-pk
+          opam depext -y mirage-crypto mirage-crypto-rng mirage-crypto-rng-mirage mirage-crypto-pk
           opam install -t --deps-only .
 
       - name: Build

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ services:
 os: linux
 env:
   global:
-    - PINS="mirage-crypto.dev:. mirage-crypto-rng.dev:. mirage-crypto-pk.dev:."
+    - PINS="mirage-crypto.dev:. mirage-crypto-rng.dev:. mirage-crypto-rng-mirage.dev:. mirage-crypto-pk.dev:."
     - PACKAGE="mirage-crypto-pk"
     - TESTS=true
     - DISTRO=alpine

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,16 @@
+## v0.8.0
+
+* New package mirage-crypto-rng-mirage which contains the entropy collection
+  code for MirageOS (#69 requested by @samoht, implemented by @hannesm)
+* Mirage_crypto_rng_lwt.initialize is not inside the Lwt monad anymore, and
+  thus can be called by libraries at top level (#69, requested by @avsm @xguerin
+  @talex5 in mirage/ocaml-conduit#318, implemented by @hannesm)
+* Both Mirage_crypto_rng_lwt.initialize and Mirage_crypto_rng_unix.initialize
+  don't do anything if called a second time (#69, implemented by @hannesm)
+* Entropy source registration is now open and done via
+  `Entropy.register_source : string -> source`, instead of a closed variant
+  (#69, fixes #68, implemented by @hannesm)
+
 ## v0.7.0 (2020-05-18)
 
 * CPU feature detection (AESNI, SSE3, PCLMULQ) at runtime instead of compile

--- a/mirage-crypto-rng-mirage.opam
+++ b/mirage-crypto-rng-mirage.opam
@@ -6,7 +6,7 @@ doc:          "https://mirage.github.io/mirage-crypto/doc"
 authors:      ["David Kaloper <dk505@cam.ac.uk>" "Hannes Mehnert <hannes@mehnert.org>" ]
 maintainer:   "Hannes Mehnert <hannes@mehnert.org>"
 license:      "ISC"
-synopsis:     "A cryptographically secure PRNG"
+synopsis:     "Entropy collection for a cryptographically secure PRNG"
 
 build: [ ["dune" "subst"] {pinned}
          ["dune" "build" "-p" name "-j" jobs ]
@@ -15,19 +15,16 @@ build: [ ["dune" "subst"] {pinned}
 depends: [
   "ocaml" {>= "4.08.0"}
   "dune" {>= "1.7"}
-  "dune-configurator"
+  "mirage-crypto-rng" {=version}
   "duration"
   "cstruct" {>= "4.0.0"}
-  "logs"
-  "mirage-crypto" {=version}
-  "ounit" {with-test}
-  "randomconv" {with-test & >= "0.1.3"}
-# lwt sublibrary
-  "mtime"
-  "lwt" {>= "4.0.0"}
+  "mirage-runtime" {>= "3.7.0"}
+  "mirage-time" {>= "2.0.0"}
+  "mirage-clock" {>= "3.0.0"}
+  "mirage-unix" {with-test & >= "3.0.0"}
+  "mirage-time-unix" {with-test & >= "2.0.0"}
+  "mirage-clock-unix" {with-test & >= "3.0.0"}
 ]
 description: """
-Mirage-crypto-rng provides a random number generator interface, and
-implementations: Fortuna, HMAC-DRBG, getrandom/getentropy based (in the unix
-sublibrary)
+Mirage-crypto-rng-mirage provides entropy collection code for the RNG.
 """

--- a/rng/fortuna.ml
+++ b/rng/fortuna.ml
@@ -102,7 +102,7 @@ let generate ~g bytes =
            chunk (generate_rekey ~g n' :: acc) (n - n') in
   Cstruct.concat @@ chunk [] bytes
 
-let add ~g ~source ~pool data =
+let add ~g (source, _) ~pool data =
   let pool   = pool land (pools - 1)
   and source = source land 0xff in
   let header = Cs.of_bytes [ source ; Cstruct.len data ] in
@@ -113,8 +113,8 @@ let add ~g ~source ~pool data =
  * Schneier recommends against using generator-imposed pool-seeding schedule
  * but it just makes for a horrid api.
  *)
-let accumulate ~g ~source =
+let accumulate ~g source =
   let pool = ref 0 in
   `Acc (fun cs ->
-    add ~g ~source ~pool:!pool cs ;
+    add ~g source ~pool:!pool cs ;
     incr pool)

--- a/rng/lwt/mirage_crypto_rng_lwt.ml
+++ b/rng/lwt/mirage_crypto_rng_lwt.ml
@@ -1,5 +1,8 @@
 open Mirage_crypto_rng
 
+let src = Logs.Src.create "mirage-crypto-rng.lwt" ~doc:"Mirage crypto RNG Lwt"
+module Log = (val Logs.src_log src : Logs.LOG)
+
 let periodic f delta =
   let open Lwt.Infix in
   Lwt.async (fun () ->
@@ -34,16 +37,16 @@ let getrandom_init _ =
 
 let initialize ?(sleep = Duration.of_sec 1) () =
   if !running then
-    Logs.info
+    Log.debug
       (fun m -> m "Mirage_crypto_rng_lwt.initialize has already been called, \
                    ignoring this call.")
   else begin
     (try
        let _ = default_generator () in
-       Logs.warn (fun m -> m "Mirage_crypto_rng.default_generator has already \
-                              been set (but not via \
-                              Mirage_crypto_rng_lwt.initialize). Please check \
-                              that this is intentional");
+       Log.warn (fun m -> m "Mirage_crypto_rng.default_generator has already \
+                             been set (but not via \
+                             Mirage_crypto_rng_lwt.initialize). Please check \
+                             that this is intentional");
      with
        No_default_generator -> ());
     running := true;

--- a/rng/lwt/mirage_crypto_rng_lwt.ml
+++ b/rng/lwt/mirage_crypto_rng_lwt.ml
@@ -34,26 +34,32 @@ let getrandom_init _ =
 
 let initialize ?(sleep = Duration.of_sec 1) () =
   if !running then
-    Logs.warn
-      (fun m -> m "Mirage_crypto_rng_lwt.initialize was called before, you \
-                   should ensure this call is intentional.")
-  else
+    Logs.info
+      (fun m -> m "Mirage_crypto_rng_lwt.initialize has already been called, \
+                   ignoring this call.")
+  else begin
     (try
        let _ = default_generator () in
        Logs.warn (fun m -> m "Mirage_crypto_rng.default_generator has already \
-                              been set, check that this call is intentional");
+                              been set (but not via \
+                              Mirage_crypto_rng_lwt.initialize). Please check \
+                              that this is intentional");
      with
        No_default_generator -> ());
-  running := true;
-  let seed =
-    List.mapi (fun i f -> f i)
-      Entropy.[ bootstrap ; whirlwind_bootstrap ; bootstrap ; getrandom_init ] |>
-    Cstruct.concat
-  in
-  Entropy.add_source `Getrandom;
-  let rng = create ~seed ~time:Mtime_clock.elapsed_ns (module Fortuna) in
-  set_default_generator rng;
-  rdrand_task sleep;
-  getrandom_task (Int64.mul sleep 10L);
-  let _ = Lwt_main.Enter_iter_hooks.add_first (Entropy.timer_accumulator None) in
-  Lwt.return_unit
+    running := true;
+    let seed =
+      let init =
+        Entropy.[ bootstrap ; whirlwind_bootstrap ; bootstrap ; getrandom_init ]
+      in
+      List.mapi (fun i f -> f i) init |> Cstruct.concat
+    in
+    Entropy.add_source `Getrandom;
+    let rng = create ~seed ~time:Mtime_clock.elapsed_ns (module Fortuna) in
+    set_default_generator rng;
+    rdrand_task sleep;
+    getrandom_task (Int64.mul sleep 10L);
+    let _ =
+      Lwt_main.Enter_iter_hooks.add_first (Entropy.timer_accumulator None)
+    in
+    ()
+  end

--- a/rng/lwt/mirage_crypto_rng_lwt.mli
+++ b/rng/lwt/mirage_crypto_rng_lwt.mli
@@ -8,4 +8,4 @@
     of entropy from the CPU RNG, every [10 * sleep] getrandom is used to collect
     entropy.
 *)
-val initialize : ?sleep:int64 -> unit -> unit Lwt.t
+val initialize : ?sleep:int64 -> unit -> unit

--- a/rng/mirage/dune
+++ b/rng/mirage/dune
@@ -1,4 +1,4 @@
 (library
   (name mirage_crypto_rng_mirage)
-  (public_name mirage-crypto-rng.mirage)
-  (libraries cstruct lwt mirage-runtime mirage-crypto mirage-crypto-rng mirage-time mirage-clock duration logs))
+  (public_name mirage-crypto-rng-mirage)
+  (libraries cstruct lwt mirage-runtime mirage-crypto-rng mirage-time mirage-clock duration logs))

--- a/rng/mirage/mirage_crypto_rng_mirage.ml
+++ b/rng/mirage/mirage_crypto_rng_mirage.ml
@@ -28,6 +28,9 @@
  *)
 open Mirage_crypto_rng
 
+let src = Logs.Src.create "mirage-crypto-rng-mirage" ~doc:"Mirage crypto RNG mirage"
+module Log = (val Logs.src_log src : Logs.LOG)
+
 module Make (T : Mirage_time.S) (M : Mirage_clock.MCLOCK) = struct
   let rdrand_task g delta =
     let open Lwt.Infix in
@@ -51,8 +54,8 @@ module Make (T : Mirage_time.S) (M : Mirage_clock.MCLOCK) = struct
     else begin
       (try
          let _ = default_generator () in
-         Logs.warn (fun m -> m "Mirage_crypto_rng.default_generator has already \
-                                been set, check that this call is intentional");
+         Log.warn (fun m -> m "Mirage_crypto_rng.default_generator has already \
+                               been set, check that this call is intentional");
        with
          No_default_generator -> ());
       running := true;

--- a/rng/rng.ml
+++ b/rng/rng.ml
@@ -1,3 +1,5 @@
+type source = int * string
+
 type bits = int
 
 exception Unseeded_generator
@@ -33,7 +35,7 @@ module type Generator = sig
   val create     : ?time:(unit -> int64) -> unit -> g
   val generate   : g:g -> int -> Cstruct.t
   val reseed     : g:g -> Cstruct.t -> unit
-  val accumulate : g:g -> source:int -> [`Acc of Cstruct.t -> unit]
+  val accumulate : g:g -> source -> [`Acc of Cstruct.t -> unit]
   val seeded     : g:g -> bool
   val pools      : int
 end
@@ -64,10 +66,10 @@ let generate ?(g = default_generator ()) n =
 let reseed ?(g = default_generator ()) cs =
   let Generator (g, _, m) = g in let module M = (val m) in M.reseed ~g cs
 
-let accumulate g ~source =
+let accumulate g source =
   let Generator (g, _, m) = get g in
   let module M = (val m) in
-  M.accumulate ~g ~source
+  M.accumulate ~g source
 
 let seeded g =
   let Generator (g, _, m) = get g in let module M = (val m) in M.seeded ~g

--- a/rng/unix/mirage_crypto_rng_unix.ml
+++ b/rng/unix/mirage_crypto_rng_unix.ml
@@ -12,9 +12,9 @@ let getrandom size =
   getrandom_buf buf.Cstruct.buffer size;
   buf
 
-let getrandom_init _ =
+let getrandom_init i =
   let data = getrandom 128 in
-  Entropy.header `Getrandom data
+  Entropy.header i data
 
 let running = ref false
 
@@ -37,6 +37,6 @@ let initialize () =
       in
       List.mapi (fun i f -> f i) init |> Cstruct.concat
     in
-    Entropy.add_source `Getrandom;
+    let _ = Entropy.register_source "getrandom" in
     set_default_generator (create ~seed (module Fortuna))
   end

--- a/rng/unix/mirage_crypto_rng_unix.ml
+++ b/rng/unix/mirage_crypto_rng_unix.ml
@@ -1,5 +1,8 @@
 open Mirage_crypto_rng
 
+let src = Logs.Src.create "mirage-crypto-rng.unix" ~doc:"Mirage crypto RNG Unix"
+module Log = (val Logs.src_log src : Logs.LOG)
+
 open Stdlib.Bigarray
 type buffer = (char, int8_unsigned_elt, c_layout) Array1.t
 external getrandom_buf : buffer -> int -> unit = "mc_getrandom"
@@ -17,14 +20,14 @@ let running = ref false
 
 let initialize () =
   if !running then
-    Logs.warn
+    Log.debug
       (fun m -> m "Mirage_crypto_rng_unix.initialize has already been called, \
                    ignoring this call.")
   else begin
     (try
        let _ = default_generator () in
-       Logs.warn (fun m -> m "Mirage_crypto_rng.default_generator has already \
-                              been set, check that this call is intentional");
+       Log.warn (fun m -> m "Mirage_crypto_rng.default_generator has already \
+                             been set, check that this call is intentional");
      with
        No_default_generator -> ());
     running := true ;

--- a/tests/dune
+++ b/tests/dune
@@ -30,5 +30,5 @@
 (test
  (name test_entropy)
  (modules test_entropy)
- (package mirage-crypto-rng)
- (libraries mirage-crypto-rng.mirage mirage-unix mirage-time-unix mirage-clock-unix))
+ (package mirage-crypto-rng-mirage)
+ (libraries mirage-crypto-rng-mirage mirage-unix mirage-time-unix mirage-clock-unix))

--- a/tests/test_entropy.ml
+++ b/tests/test_entropy.ml
@@ -12,9 +12,10 @@ module Printing_rng = struct
   let reseed ~g:_ data =
     Format.printf "reseeding: %a@.%!" Cstruct.hexdump_pp data
 
-  let accumulate ~g:_ ~source =
+  let accumulate ~g:_ source =
     let print data =
-      Format.printf "accumulate: (src:%d) %a@.%!" source Cstruct.hexdump_pp data
+      Format.printf "accumulate: (src: %a) %a@.%!"
+        Mirage_crypto_rng.Entropy.pp_source source Cstruct.hexdump_pp data
     in
     `Acc print
 

--- a/tests/test_rsa.ml
+++ b/tests/test_rsa.ml
@@ -26,7 +26,7 @@ module Null = struct
 
   let seeded ~g = Cstruct.len !g > 0
 
-  let accumulate ~g ~source:_ = `Acc (reseed ~g)
+  let accumulate ~g _source = `Acc (reseed ~g)
 
   let pools = 0
 end


### PR DESCRIPTION
Calling Lwt.async and Lwt_unix.Enter_iter_hooks.add_first does not need to be
inside of the Lwt_main.run. This allows library code to execute
Mirage_crypto_rng_lwt.initialize () at top level.

Initialization is only done once (the `running` (bool ref) is used to figure out
whether initialize was already called before).