### PR TITLE
mirage-crypto-rng-mirage: require mirage-runtime 3.8.0 to avoid broken installations, mirage-crypto-rng: conflict with mirage-runtime <3.8.0

### DIFF
--- a/mirage-crypto-rng-mirage.opam
+++ b/mirage-crypto-rng-mirage.opam
@@ -18,7 +18,7 @@ depends: [
   "mirage-crypto-rng" {=version}
   "duration"
   "cstruct" {>= "4.0.0"}
-  "mirage-runtime" {>= "3.7.0"}
+  "mirage-runtime" {>= "3.8.0"}
   "mirage-time" {>= "2.0.0"}
   "mirage-clock" {>= "3.0.0"}
   "mirage-unix" {with-test & >= "3.0.0"}

--- a/mirage-crypto-rng.opam
+++ b/mirage-crypto-rng.opam
@@ -26,6 +26,7 @@ depends: [
   "mtime"
   "lwt" {>= "4.0.0"}
 ]
+conflicts: [ "mirage-runtime" {< "3.8.0"} ]
 description: """
 Mirage-crypto-rng provides a random number generator interface, and
 implementations: Fortuna, HMAC-DRBG, getrandom/getentropy based (in the unix


### PR DESCRIPTION
what happened:
- mirage outputs a dependency (when using the random device) on mirage-crypto-rng ~min:"0.7".
- it uses Mirage_crypto_rng_mirage.initialize () (from the mirage-crypto-rng.mirage sublibrary)

now, that sublibrary is gone in 0.8, and part of the separate mirage-crypto-rng-mirage package. since existing mirage tools do not emit an upper bound for the dependency, we need to ensure that no 3.7 unikernel will use mirage-crypto-rng.0.8 (otherwise a link failure will occur that mirage-crypto-rng.mirage does not exist).