### PR TITLE
Add Chacha20 cipher, and poly1305 mac

### DIFF
--- a/freestanding/dune
+++ b/freestanding/dune
@@ -7,7 +7,7 @@
  (libraries ocaml-freestanding)
  (c_flags (:standard) (:include ../src/cflags.sexp) (:include cflags-freestanding.sexp))
  (c_names detect_cpu_features misc misc_sse hash_stubs md5 sha1 sha256 sha512
-          aes_generic aes_aesni des_generic
+          aes_generic aes_aesni des_generic chacha
           ghash_pclmul ghash_generic ghash_ctmul
           entropy_cpu_stubs)
 )

--- a/freestanding/dune
+++ b/freestanding/dune
@@ -7,7 +7,7 @@
  (libraries ocaml-freestanding)
  (c_flags (:standard) (:include ../src/cflags.sexp) (:include cflags-freestanding.sexp))
  (c_names detect_cpu_features misc misc_sse hash_stubs md5 sha1 sha256 sha512
-          aes_generic aes_aesni des_generic chacha
+          aes_generic aes_aesni des_generic chacha poly1305-donna
           ghash_pclmul ghash_generic ghash_ctmul
           entropy_cpu_stubs)
 )

--- a/src/chacha20.ml
+++ b/src/chacha20.ml
@@ -1,0 +1,56 @@
+(* Based on https://github.com/abeaumont/ocaml-chacha.git *)
+
+open Uncommon
+
+let block = 64
+
+let chacha20_block state idx key_stream =
+  Native.Chacha.round 10 state.Cstruct.buffer 0 key_stream.Cstruct.buffer idx
+
+let init ctr ~key ~nonce =
+  let ctr_off = 48 in
+  let set_ctr32 b v = Cstruct.LE.set_uint32 b ctr_off v
+  and set_ctr64 b v = Cstruct.LE.set_uint64 b ctr_off v
+  in
+  let inc32 b = set_ctr32 b (Int32.add (Cstruct.LE.get_uint32 b ctr_off) 1l)
+  and inc64 b = set_ctr64 b (Int64.add (Cstruct.LE.get_uint64 b ctr_off) 1L)
+  in
+  let s, key, init_ctr, nonce_off, inc =
+    match Cstruct.len key, Cstruct.len nonce, Int64.shift_right ctr 32 = 0L with
+    | 32, 12, true ->
+      let ctr = Int64.to_int32 ctr in
+      "expand 32-byte k", key, (fun b -> set_ctr32 b ctr), 52, inc32
+    | 32, 12, false ->
+      invalid_arg "Counter too big for IETF mode (32 bit counter)"
+    | 32, 8, _ ->
+      "expand 32-byte k", key, (fun b -> set_ctr64 b ctr), 56, inc64
+    | 16, 8, _ ->
+      let k = Cstruct.append key key in
+      "expand 16-byte k", k, (fun b -> set_ctr64 b ctr), 56, inc64
+    | _ -> invalid_arg "Valid parameters are nonce 12 bytes and key 32 bytes \
+                        (counter 32 bit), or nonce 8 byte and key 16 or 32 \
+                        bytes (counter 64 bit)."
+  in
+  let state = Cstruct.create block in
+  Cstruct.blit_from_string s 0 state 0 16 ;
+  Cstruct.blit key 0 state 16 32 ;
+  init_ctr state ;
+  Cstruct.blit nonce 0 state nonce_off (Cstruct.len nonce) ;
+  state, inc
+
+let crypt ~key ~nonce ?(ctr = 0L) data =
+  let state, inc = init ctr ~key ~nonce in
+  let l = Cstruct.len data in
+  let block_count = l // block in
+  let len = block * block_count in
+  let key_stream = Cstruct.create_unsafe len in
+  let rec loop i = function
+    | 0 -> ()
+    | n ->
+      chacha20_block state i key_stream ;
+      Native.xor_into data.buffer (data.off + i) key_stream.buffer i block ;
+      inc state;
+      loop (i + block) (n - 1)
+  in
+  loop 0 block_count ;
+  Cstruct.sub key_stream 0 l

--- a/src/dune
+++ b/src/dune
@@ -2,13 +2,14 @@
   (name mirage_crypto)
   (public_name mirage-crypto)
   (libraries cstruct)
-  (private_modules ccm cipher_block cipher_stream hash native uncommon)
+  (private_modules chacha20 ccm cipher_block cipher_stream hash native uncommon)
   (c_names detect_cpu_features
            misc misc_sse
            md5 sha1 sha256 sha512 hash_stubs
            aes_generic aes_aesni
            ghash_generic ghash_pclmul ghash_ctmul
            des_generic
+           chacha
            entropy_cpu_stubs)
   (c_flags (:standard) (:include cflags.sexp)))
 

--- a/src/dune
+++ b/src/dune
@@ -2,14 +2,14 @@
   (name mirage_crypto)
   (public_name mirage-crypto)
   (libraries cstruct)
-  (private_modules chacha20 ccm cipher_block cipher_stream hash native uncommon)
+  (private_modules chacha20 ccm cipher_block cipher_stream hash native poly1305 uncommon)
   (c_names detect_cpu_features
            misc misc_sse
            md5 sha1 sha256 sha512 hash_stubs
            aes_generic aes_aesni
            ghash_generic ghash_pclmul ghash_ctmul
            des_generic
-           chacha
+           chacha poly1305-donna
            entropy_cpu_stubs)
   (c_flags (:standard) (:include cflags.sexp)))
 

--- a/src/mirage_crypto.ml
+++ b/src/mirage_crypto.ml
@@ -1,5 +1,6 @@
 module Uncommon = Uncommon
 module Hash = Hash
+module Poly1305 = Poly1305.It
 module Cipher_block = Cipher_block
 module Chacha20 = Chacha20
 module Cipher_stream = Cipher_stream

--- a/src/mirage_crypto.ml
+++ b/src/mirage_crypto.ml
@@ -1,4 +1,5 @@
 module Uncommon = Uncommon
 module Hash = Hash
 module Cipher_block = Cipher_block
+module Chacha20 = Chacha20
 module Cipher_stream = Cipher_stream

--- a/src/mirage_crypto.mli
+++ b/src/mirage_crypto.mli
@@ -487,6 +487,20 @@ module Chacha20 : sig
       IETF mode (and counter fit into 32 bits), or [key] must be either 16
       bytes or 32 bytes and [nonce] 8 bytes.
   *)
+
+  val aead_poly1305_encrypt : key:Cstruct.t -> nonce:Cstruct.t ->
+    ?adata:Cstruct.t -> Cstruct.t -> Cstruct.t
+  (** [aead_poly1305_encrypt ~key ~nonce ~adata data] encrypts [data]
+      with ChaCha20 using [key] and [nonce]. Additionally, an authentication
+      tag using {!Poly1305} is appended to the output. This conforms to
+      RFC 8439 Section 2.8. *)
+
+  val aead_poly1305_decrypt : key:Cstruct.t -> nonce:Cstruct.t ->
+    ?adata:Cstruct.t -> Cstruct.t -> Cstruct.t option
+  (** [aead_poly1305_decrypt ~key ~nonce ~adata data] decrypts [data] with
+      ChaCha20 using [key] and [nonce]. Also, the authentication tag is split
+      off the end of [data] and verified using {!Poly1305}. This conforms to
+      RFC 8439 Section 2.8. *)
 end
 
 (** Streaming ciphers. *)

--- a/src/mirage_crypto.mli
+++ b/src/mirage_crypto.mli
@@ -187,6 +187,40 @@ module Hash : sig
   (** [digest_size algorithm] is the size of the [algorithm] in bytes. *)
 end
 
+(** The poly1305 message authentication code *)
+module Poly1305 : sig
+  type mac = Cstruct.t
+
+  type 'a iter = ('a -> unit) -> unit
+
+  type t
+  (** Represents a running mac computation, suitable for appending inputs. *)
+
+  val mac_size : int
+  (** [mac_size] is the size of the output. *)
+
+  val empty : key:Cstruct.t -> t
+  (** [empty] is the empty context with the given [key].
+
+      @raise Invalid_argument if key is not 32 bytes. *)
+
+  val feed : t -> Cstruct.t -> t
+  (** [feed t msg] adds the information in [msg] to [t]. *)
+
+  val feedi : t -> Cstruct.t iter -> t
+  (** [feedi t iter] feeds iter into [t]. *)
+
+  val get : t -> mac
+  (** [get t] is the mac corresponding to [t]. *)
+
+  val mac : key:Cstruct.t -> Cstruct.t -> mac
+  (** [mac ~key msg] is the all-in-one mac computation:
+      [get (feed (empty ~key) msg)]. *)
+
+  val maci : key:Cstruct.t -> Cstruct.t iter -> mac
+  (** [maci ~key iter] is the all-in-one mac computation:
+      [get (feedi (empty ~key) iter)]. *)
+end
 
 (** {1 Symmetric-key cryptography} *)
 

--- a/src/mirage_crypto.mli
+++ b/src/mirage_crypto.mli
@@ -437,6 +437,23 @@ module Cipher_block : sig
       this build of the library. *)
 end
 
+(** The ChaCha20 cipher proposed by D.J. Bernstein. *)
+module Chacha20 : sig
+  val crypt : key:Cstruct.t -> nonce:Cstruct.t -> ?ctr:int64 -> Cstruct.t -> Cstruct.t
+  (** [crypt ~key ~nonce ~ctr data] generates a ChaCha20 key stream using
+      the [key], and [nonce]. The [ctr] defaults to 0. The generated key
+      stream is of the same length as [data], and the output is the XOR
+      of the key stream and [data]. This implements, depending on the size
+      of the [nonce] (8 or 12 bytes) both the original specification (where
+      the counter is 8 byte, same as the nonce) and the IETF RFC 8439
+      specification (where nonce is 12 bytes, and counter 4 bytes).
+
+      @raise Invalid_argument if invalid parameters are provided. Valid
+      parameters are: [key] must be 32 bytes and [nonce] 12 bytes for the
+      IETF mode (and counter fit into 32 bits), or [key] must be either 16
+      bytes or 32 bytes and [nonce] 8 bytes.
+  *)
+end
 
 (** Streaming ciphers. *)
 module Cipher_stream : sig

--- a/src/native.ml
+++ b/src/native.ml
@@ -30,6 +30,10 @@ module DES = struct
   external k_s     : unit -> int = "mc_des_key_size" [@@noalloc]
 end
 
+module Chacha = struct
+  external round : int -> buffer -> off -> buffer -> off -> unit = "mc_chacha_round" [@@noalloc]
+end
+
 module MD5 = struct
   external init     : ctx -> unit = "mc_md5_init" [@@noalloc]
   external update   : ctx -> buffer -> off -> size -> unit = "mc_md5_update" [@@noalloc]

--- a/src/native.ml
+++ b/src/native.ml
@@ -34,6 +34,14 @@ module Chacha = struct
   external round : int -> buffer -> off -> buffer -> off -> unit = "mc_chacha_round" [@@noalloc]
 end
 
+module Poly1305 = struct
+  external init     : ctx -> buffer -> off -> unit = "mc_poly1305_init" [@@noalloc]
+  external update   : ctx -> buffer -> off -> size -> unit = "mc_poly1305_update" [@@noalloc]
+  external finalize : ctx -> buffer -> off -> unit = "mc_poly1305_finalize" [@@noalloc]
+  external ctx_size : unit -> int = "mc_poly1305_ctx_size" [@@noalloc]
+  external mac_size : unit -> int = "mc_poly1305_mac_size" [@@noalloc]
+end
+
 module MD5 = struct
   external init     : ctx -> unit = "mc_md5_init" [@@noalloc]
   external update   : ctx -> buffer -> off -> size -> unit = "mc_md5_update" [@@noalloc]

--- a/src/native/chacha.c
+++ b/src/native/chacha.c
@@ -1,0 +1,55 @@
+/* Based on https://github.com/abeaumont/ocaml-chacha.git */
+
+#include "mirage_crypto.h"
+
+static inline void mc_chacha_quarterround(uint32_t *x, int a, int b, int c, int d) {
+  x[a] += x[b]; x[d] = rol32(x[d] ^ x[a], 16);
+  x[c] += x[d]; x[b] = rol32(x[b] ^ x[c], 12);
+  x[a] += x[b]; x[d] = rol32(x[d] ^ x[a], 8);
+  x[c] += x[d]; x[b] = rol32(x[b] ^ x[c], 7);
+}
+
+static inline uint32_t mc_get_u32_le(uint8_t *input, int offset) {
+  return input[offset]
+    | (input[offset + 1] << 8)
+    | (input[offset + 2] << 16)
+    | (input[offset + 3] << 24);
+}
+
+static inline void mc_set_u32_le(uint8_t *input, int offset, uint32_t value) {
+  input[offset] = (uint8_t) value;
+  input[offset + 1] = (uint8_t) (value >> 8);
+  input[offset + 2] = (uint8_t) (value >> 16);
+  input[offset + 3] = (uint8_t) (value >> 24);
+}
+
+static void mc_chacha_core(int count, uint8_t *src, uint8_t *dst) {
+  uint32_t x[16];
+  for (int i = 0; i < 16; i++) {
+    x[i] = mc_get_u32_le(src, i * 4);
+  }
+  for (int i = 0; i < count; i++) {
+    mc_chacha_quarterround(x, 0, 4, 8, 12);
+    mc_chacha_quarterround(x, 1, 5, 9, 13);
+    mc_chacha_quarterround(x, 2, 6, 10, 14);
+    mc_chacha_quarterround(x, 3, 7, 11, 15);
+
+    mc_chacha_quarterround(x, 0, 5, 10, 15);
+    mc_chacha_quarterround(x, 1, 6, 11, 12);
+    mc_chacha_quarterround(x, 2, 7, 8, 13);
+    mc_chacha_quarterround(x, 3, 4, 9, 14);
+  }
+  for (int i = 0; i < 16; i++) {
+    uint32_t xi = x[i];
+    uint32_t hj = mc_get_u32_le(src, i * 4);
+    mc_set_u32_le(dst, i * 4, xi + hj);
+  }
+}
+
+CAMLprim value
+mc_chacha_round(value count, value src, value off1, value dst, value off2)
+{
+  mc_chacha_core(Int_val(count), _ba_uint8_off(src, off1), _ba_uint8_off(dst, off2));
+  return Val_unit;
+}
+

--- a/src/native/poly1305-donna-32.h
+++ b/src/native/poly1305-donna-32.h
@@ -1,0 +1,221 @@
+// from https://github.com/floodyberry/poly1305-donna.git
+
+/*
+	poly1305 implementation using 32 bit * 32 bit = 64 bit multiplication and 64 bit addition
+*/
+
+#if defined(_MSC_VER)
+	#define POLY1305_NOINLINE __declspec(noinline)
+#elif defined(__GNUC__)
+	#define POLY1305_NOINLINE __attribute__((noinline))
+#else
+	#define POLY1305_NOINLINE
+#endif
+
+#define poly1305_block_size 16
+
+/* 17 + sizeof(size_t) + 14*sizeof(unsigned long) */
+typedef struct poly1305_state_internal_t {
+	unsigned long r[5];
+	unsigned long h[5];
+	unsigned long pad[4];
+	size_t leftover;
+	unsigned char buffer[poly1305_block_size];
+	unsigned char final;
+} poly1305_state_internal_t;
+
+/* interpret four 8 bit unsigned integers as a 32 bit unsigned integer in little endian */
+static unsigned long
+U8TO32(const unsigned char *p) {
+	return
+		(((unsigned long)(p[0] & 0xff)      ) |
+	     ((unsigned long)(p[1] & 0xff) <<  8) |
+         ((unsigned long)(p[2] & 0xff) << 16) |
+         ((unsigned long)(p[3] & 0xff) << 24));
+}
+
+/* store a 32 bit unsigned integer as four 8 bit unsigned integers in little endian */
+static void
+U32TO8(unsigned char *p, unsigned long v) {
+	p[0] = (v      ) & 0xff;
+	p[1] = (v >>  8) & 0xff;
+	p[2] = (v >> 16) & 0xff;
+	p[3] = (v >> 24) & 0xff;
+}
+
+void
+poly1305_init(poly1305_context *ctx, const unsigned char key[32]) {
+	poly1305_state_internal_t *st = (poly1305_state_internal_t *)ctx;
+
+	/* r &= 0xffffffc0ffffffc0ffffffc0fffffff */
+	st->r[0] = (U8TO32(&key[ 0])     ) & 0x3ffffff;
+	st->r[1] = (U8TO32(&key[ 3]) >> 2) & 0x3ffff03;
+	st->r[2] = (U8TO32(&key[ 6]) >> 4) & 0x3ffc0ff;
+	st->r[3] = (U8TO32(&key[ 9]) >> 6) & 0x3f03fff;
+	st->r[4] = (U8TO32(&key[12]) >> 8) & 0x00fffff;
+
+	/* h = 0 */
+	st->h[0] = 0;
+	st->h[1] = 0;
+	st->h[2] = 0;
+	st->h[3] = 0;
+	st->h[4] = 0;
+
+	/* save pad for later */
+	st->pad[0] = U8TO32(&key[16]);
+	st->pad[1] = U8TO32(&key[20]);
+	st->pad[2] = U8TO32(&key[24]);
+	st->pad[3] = U8TO32(&key[28]);
+
+	st->leftover = 0;
+	st->final = 0;
+}
+
+static void
+poly1305_blocks(poly1305_state_internal_t *st, const unsigned char *m, size_t bytes) {
+	const unsigned long hibit = (st->final) ? 0 : (1UL << 24); /* 1 << 128 */
+	unsigned long r0,r1,r2,r3,r4;
+	unsigned long s1,s2,s3,s4;
+	unsigned long h0,h1,h2,h3,h4;
+	unsigned long long d0,d1,d2,d3,d4;
+	unsigned long c;
+
+	r0 = st->r[0];
+	r1 = st->r[1];
+	r2 = st->r[2];
+	r3 = st->r[3];
+	r4 = st->r[4];
+
+	s1 = r1 * 5;
+	s2 = r2 * 5;
+	s3 = r3 * 5;
+	s4 = r4 * 5;
+
+	h0 = st->h[0];
+	h1 = st->h[1];
+	h2 = st->h[2];
+	h3 = st->h[3];
+	h4 = st->h[4];
+
+	while (bytes >= poly1305_block_size) {
+		/* h += m[i] */
+		h0 += (U8TO32(m+ 0)     ) & 0x3ffffff;
+		h1 += (U8TO32(m+ 3) >> 2) & 0x3ffffff;
+		h2 += (U8TO32(m+ 6) >> 4) & 0x3ffffff;
+		h3 += (U8TO32(m+ 9) >> 6) & 0x3ffffff;
+		h4 += (U8TO32(m+12) >> 8) | hibit;
+
+		/* h *= r */
+		d0 = ((unsigned long long)h0 * r0) + ((unsigned long long)h1 * s4) + ((unsigned long long)h2 * s3) + ((unsigned long long)h3 * s2) + ((unsigned long long)h4 * s1);
+		d1 = ((unsigned long long)h0 * r1) + ((unsigned long long)h1 * r0) + ((unsigned long long)h2 * s4) + ((unsigned long long)h3 * s3) + ((unsigned long long)h4 * s2);
+		d2 = ((unsigned long long)h0 * r2) + ((unsigned long long)h1 * r1) + ((unsigned long long)h2 * r0) + ((unsigned long long)h3 * s4) + ((unsigned long long)h4 * s3);
+		d3 = ((unsigned long long)h0 * r3) + ((unsigned long long)h1 * r2) + ((unsigned long long)h2 * r1) + ((unsigned long long)h3 * r0) + ((unsigned long long)h4 * s4);
+		d4 = ((unsigned long long)h0 * r4) + ((unsigned long long)h1 * r3) + ((unsigned long long)h2 * r2) + ((unsigned long long)h3 * r1) + ((unsigned long long)h4 * r0);
+
+		/* (partial) h %= p */
+		              c = (unsigned long)(d0 >> 26); h0 = (unsigned long)d0 & 0x3ffffff;
+		d1 += c;      c = (unsigned long)(d1 >> 26); h1 = (unsigned long)d1 & 0x3ffffff;
+		d2 += c;      c = (unsigned long)(d2 >> 26); h2 = (unsigned long)d2 & 0x3ffffff;
+		d3 += c;      c = (unsigned long)(d3 >> 26); h3 = (unsigned long)d3 & 0x3ffffff;
+		d4 += c;      c = (unsigned long)(d4 >> 26); h4 = (unsigned long)d4 & 0x3ffffff;
+		h0 += c * 5;  c =                (h0 >> 26); h0 =                h0 & 0x3ffffff;
+		h1 += c;
+
+		m += poly1305_block_size;
+		bytes -= poly1305_block_size;
+	}
+
+	st->h[0] = h0;
+	st->h[1] = h1;
+	st->h[2] = h2;
+	st->h[3] = h3;
+	st->h[4] = h4;
+}
+
+POLY1305_NOINLINE void
+poly1305_finish(poly1305_context *ctx, unsigned char mac[16]) {
+	poly1305_state_internal_t *st = (poly1305_state_internal_t *)ctx;
+	unsigned long h0,h1,h2,h3,h4,c;
+	unsigned long g0,g1,g2,g3,g4;
+	unsigned long long f;
+	unsigned long mask;
+
+	/* process the remaining block */
+	if (st->leftover) {
+		size_t i = st->leftover;
+		st->buffer[i++] = 1;
+		for (; i < poly1305_block_size; i++)
+			st->buffer[i] = 0;
+		st->final = 1;
+		poly1305_blocks(st, st->buffer, poly1305_block_size);
+	}
+
+	/* fully carry h */
+	h0 = st->h[0];
+	h1 = st->h[1];
+	h2 = st->h[2];
+	h3 = st->h[3];
+	h4 = st->h[4];
+
+	             c = h1 >> 26; h1 = h1 & 0x3ffffff;
+	h2 +=     c; c = h2 >> 26; h2 = h2 & 0x3ffffff;
+	h3 +=     c; c = h3 >> 26; h3 = h3 & 0x3ffffff;
+	h4 +=     c; c = h4 >> 26; h4 = h4 & 0x3ffffff;
+	h0 += c * 5; c = h0 >> 26; h0 = h0 & 0x3ffffff;
+	h1 +=     c;
+
+	/* compute h + -p */
+	g0 = h0 + 5; c = g0 >> 26; g0 &= 0x3ffffff;
+	g1 = h1 + c; c = g1 >> 26; g1 &= 0x3ffffff;
+	g2 = h2 + c; c = g2 >> 26; g2 &= 0x3ffffff;
+	g3 = h3 + c; c = g3 >> 26; g3 &= 0x3ffffff;
+	g4 = h4 + c - (1UL << 26);
+
+	/* select h if h < p, or h + -p if h >= p */
+	mask = (g4 >> ((sizeof(unsigned long) * 8) - 1)) - 1;
+	g0 &= mask;
+	g1 &= mask;
+	g2 &= mask;
+	g3 &= mask;
+	g4 &= mask;
+	mask = ~mask;
+	h0 = (h0 & mask) | g0;
+	h1 = (h1 & mask) | g1;
+	h2 = (h2 & mask) | g2;
+	h3 = (h3 & mask) | g3;
+	h4 = (h4 & mask) | g4;
+
+	/* h = h % (2^128) */
+	h0 = ((h0      ) | (h1 << 26)) & 0xffffffff;
+	h1 = ((h1 >>  6) | (h2 << 20)) & 0xffffffff;
+	h2 = ((h2 >> 12) | (h3 << 14)) & 0xffffffff;
+	h3 = ((h3 >> 18) | (h4 <<  8)) & 0xffffffff;
+
+	/* mac = (h + pad) % (2^128) */
+	f = (unsigned long long)h0 + st->pad[0]            ; h0 = (unsigned long)f;
+	f = (unsigned long long)h1 + st->pad[1] + (f >> 32); h1 = (unsigned long)f;
+	f = (unsigned long long)h2 + st->pad[2] + (f >> 32); h2 = (unsigned long)f;
+	f = (unsigned long long)h3 + st->pad[3] + (f >> 32); h3 = (unsigned long)f;
+
+	U32TO8(mac +  0, h0);
+	U32TO8(mac +  4, h1);
+	U32TO8(mac +  8, h2);
+	U32TO8(mac + 12, h3);
+
+	/* zero out the state */
+	st->h[0] = 0;
+	st->h[1] = 0;
+	st->h[2] = 0;
+	st->h[3] = 0;
+	st->h[4] = 0;
+	st->r[0] = 0;
+	st->r[1] = 0;
+	st->r[2] = 0;
+	st->r[3] = 0;
+	st->r[4] = 0;
+	st->pad[0] = 0;
+	st->pad[1] = 0;
+	st->pad[2] = 0;
+	st->pad[3] = 0;
+}
+

--- a/src/native/poly1305-donna-64.h
+++ b/src/native/poly1305-donna-64.h
@@ -1,0 +1,204 @@
+// from https://github.com/floodyberry/poly1305-donna.git
+
+/*
+	poly1305 implementation using 64 bit * 64 bit = 128 bit multiplication and 128 bit addition
+*/
+
+#define uint128_t __uint128_t
+#define MUL(out, x, y) out = ((uint128_t)x * y)
+#define ADD(out, in) out += in
+#define ADDLO(out, in) out += in
+#define SHR(in, shift) (unsigned long long)(in >> (shift))
+#define LO(in) (unsigned long long)(in)
+
+#define POLY1305_NOINLINE __attribute__((noinline))
+
+#define poly1305_block_size 16
+
+/* 17 + sizeof(size_t) + 8*sizeof(unsigned long long) */
+typedef struct poly1305_state_internal_t {
+	unsigned long long r[3];
+	unsigned long long h[3];
+	unsigned long long pad[2];
+	size_t leftover;
+	unsigned char buffer[poly1305_block_size];
+	unsigned char final;
+} poly1305_state_internal_t;
+
+/* interpret eight 8 bit unsigned integers as a 64 bit unsigned integer in little endian */
+static unsigned long long
+U8TO64(const unsigned char *p) {
+	return
+		(((unsigned long long)(p[0] & 0xff)      ) |
+		 ((unsigned long long)(p[1] & 0xff) <<  8) |
+		 ((unsigned long long)(p[2] & 0xff) << 16) |
+		 ((unsigned long long)(p[3] & 0xff) << 24) |
+		 ((unsigned long long)(p[4] & 0xff) << 32) |
+		 ((unsigned long long)(p[5] & 0xff) << 40) |
+		 ((unsigned long long)(p[6] & 0xff) << 48) |
+		 ((unsigned long long)(p[7] & 0xff) << 56));
+}
+
+/* store a 64 bit unsigned integer as eight 8 bit unsigned integers in little endian */
+static void
+U64TO8(unsigned char *p, unsigned long long v) {
+	p[0] = (v      ) & 0xff;
+	p[1] = (v >>  8) & 0xff;
+	p[2] = (v >> 16) & 0xff;
+	p[3] = (v >> 24) & 0xff;
+	p[4] = (v >> 32) & 0xff;
+	p[5] = (v >> 40) & 0xff;
+	p[6] = (v >> 48) & 0xff;
+	p[7] = (v >> 56) & 0xff;
+}
+
+void
+poly1305_init(poly1305_context *ctx, const unsigned char key[32]) {
+	poly1305_state_internal_t *st = (poly1305_state_internal_t *)ctx;
+	unsigned long long t0,t1;
+
+	/* r &= 0xffffffc0ffffffc0ffffffc0fffffff */
+	t0 = U8TO64(&key[0]);
+	t1 = U8TO64(&key[8]);
+
+	st->r[0] = ( t0                    ) & 0xffc0fffffff;
+	st->r[1] = ((t0 >> 44) | (t1 << 20)) & 0xfffffc0ffff;
+	st->r[2] = ((t1 >> 24)             ) & 0x00ffffffc0f;
+
+	/* h = 0 */
+	st->h[0] = 0;
+	st->h[1] = 0;
+	st->h[2] = 0;
+
+	/* save pad for later */
+	st->pad[0] = U8TO64(&key[16]);
+	st->pad[1] = U8TO64(&key[24]);
+
+	st->leftover = 0;
+	st->final = 0;
+}
+
+static void
+poly1305_blocks(poly1305_state_internal_t *st, const unsigned char *m, size_t bytes) {
+	const unsigned long long hibit = (st->final) ? 0 : ((unsigned long long)1 << 40); /* 1 << 128 */
+	unsigned long long r0,r1,r2;
+	unsigned long long s1,s2;
+	unsigned long long h0,h1,h2;
+	unsigned long long c;
+	uint128_t d0,d1,d2,d;
+
+	r0 = st->r[0];
+	r1 = st->r[1];
+	r2 = st->r[2];
+
+	h0 = st->h[0];
+	h1 = st->h[1];
+	h2 = st->h[2];
+
+	s1 = r1 * (5 << 2);
+	s2 = r2 * (5 << 2);
+
+	while (bytes >= poly1305_block_size) {
+		unsigned long long t0,t1;
+
+		/* h += m[i] */
+		t0 = U8TO64(&m[0]);
+		t1 = U8TO64(&m[8]);
+
+		h0 += (( t0                    ) & 0xfffffffffff);
+		h1 += (((t0 >> 44) | (t1 << 20)) & 0xfffffffffff);
+		h2 += (((t1 >> 24)             ) & 0x3ffffffffff) | hibit;
+
+		/* h *= r */
+		MUL(d0, h0, r0); MUL(d, h1, s2); ADD(d0, d); MUL(d, h2, s1); ADD(d0, d);
+		MUL(d1, h0, r1); MUL(d, h1, r0); ADD(d1, d); MUL(d, h2, s2); ADD(d1, d);
+		MUL(d2, h0, r2); MUL(d, h1, r1); ADD(d2, d); MUL(d, h2, r0); ADD(d2, d);
+
+		/* (partial) h %= p */
+		              c = SHR(d0, 44); h0 = LO(d0) & 0xfffffffffff;
+		ADDLO(d1, c); c = SHR(d1, 44); h1 = LO(d1) & 0xfffffffffff;
+		ADDLO(d2, c); c = SHR(d2, 42); h2 = LO(d2) & 0x3ffffffffff;
+		h0  += c * 5; c = (h0 >> 44);  h0 =    h0  & 0xfffffffffff;
+		h1  += c;
+
+		m += poly1305_block_size;
+		bytes -= poly1305_block_size;
+	}
+
+	st->h[0] = h0;
+	st->h[1] = h1;
+	st->h[2] = h2;
+}
+
+
+POLY1305_NOINLINE void
+poly1305_finish(poly1305_context *ctx, unsigned char mac[16]) {
+	poly1305_state_internal_t *st = (poly1305_state_internal_t *)ctx;
+	unsigned long long h0,h1,h2,c;
+	unsigned long long g0,g1,g2;
+	unsigned long long t0,t1;
+
+	/* process the remaining block */
+	if (st->leftover) {
+		size_t i = st->leftover;
+		st->buffer[i] = 1;
+		for (i = i + 1; i < poly1305_block_size; i++)
+			st->buffer[i] = 0;
+		st->final = 1;
+		poly1305_blocks(st, st->buffer, poly1305_block_size);
+	}
+
+	/* fully carry h */
+	h0 = st->h[0];
+	h1 = st->h[1];
+	h2 = st->h[2];
+
+	             c = (h1 >> 44); h1 &= 0xfffffffffff;
+	h2 += c;     c = (h2 >> 42); h2 &= 0x3ffffffffff;
+	h0 += c * 5; c = (h0 >> 44); h0 &= 0xfffffffffff;
+	h1 += c;     c = (h1 >> 44); h1 &= 0xfffffffffff;
+	h2 += c;     c = (h2 >> 42); h2 &= 0x3ffffffffff;
+	h0 += c * 5; c = (h0 >> 44); h0 &= 0xfffffffffff;
+	h1 += c;
+
+	/* compute h + -p */
+	g0 = h0 + 5; c = (g0 >> 44); g0 &= 0xfffffffffff;
+	g1 = h1 + c; c = (g1 >> 44); g1 &= 0xfffffffffff;
+	g2 = h2 + c - ((unsigned long long)1 << 42);
+
+	/* select h if h < p, or h + -p if h >= p */
+	c = (g2 >> ((sizeof(unsigned long long) * 8) - 1)) - 1;
+	g0 &= c;
+	g1 &= c;
+	g2 &= c;
+	c = ~c;
+	h0 = (h0 & c) | g0;
+	h1 = (h1 & c) | g1;
+	h2 = (h2 & c) | g2;
+
+	/* h = (h + pad) */
+	t0 = st->pad[0];
+	t1 = st->pad[1];
+
+	h0 += (( t0                    ) & 0xfffffffffff)    ; c = (h0 >> 44); h0 &= 0xfffffffffff;
+	h1 += (((t0 >> 44) | (t1 << 20)) & 0xfffffffffff) + c; c = (h1 >> 44); h1 &= 0xfffffffffff;
+	h2 += (((t1 >> 24)             ) & 0x3ffffffffff) + c;                 h2 &= 0x3ffffffffff;
+
+	/* mac = h % (2^128) */
+	h0 = ((h0      ) | (h1 << 44));
+	h1 = ((h1 >> 20) | (h2 << 24));
+
+	U64TO8(&mac[0], h0);
+	U64TO8(&mac[8], h1);
+
+	/* zero out the state */
+	st->h[0] = 0;
+	st->h[1] = 0;
+	st->h[2] = 0;
+	st->r[0] = 0;
+	st->r[1] = 0;
+	st->r[2] = 0;
+	st->pad[0] = 0;
+	st->pad[1] = 0;
+}
+

--- a/src/native/poly1305-donna.c
+++ b/src/native/poly1305-donna.c
@@ -1,0 +1,75 @@
+// from https://github.com/floodyberry/poly1305-donna.git
+
+#include "mirage_crypto.h"
+
+typedef struct poly1305_context {
+        size_t aligner;
+        unsigned char opaque[136];
+} poly1305_context;
+
+#if defined (__x86_64__) || defined (__aarch64__)
+#include "poly1305-donna-64.h"
+#else
+#include "poly1305-donna-32.h"
+#endif
+
+void
+poly1305_update(poly1305_context *ctx, const unsigned char *m, size_t bytes) {
+	poly1305_state_internal_t *st = (poly1305_state_internal_t *)ctx;
+	size_t i;
+
+	/* handle leftover */
+	if (st->leftover) {
+		size_t want = (poly1305_block_size - st->leftover);
+		if (want > bytes)
+			want = bytes;
+		for (i = 0; i < want; i++)
+			st->buffer[st->leftover + i] = m[i];
+		bytes -= want;
+		m += want;
+		st->leftover += want;
+		if (st->leftover < poly1305_block_size)
+			return;
+		poly1305_blocks(st, st->buffer, poly1305_block_size);
+		st->leftover = 0;
+	}
+
+	/* process full blocks */
+	if (bytes >= poly1305_block_size) {
+		size_t want = (bytes & ~(poly1305_block_size - 1));
+		poly1305_blocks(st, m, want);
+		m += want;
+		bytes -= want;
+	}
+
+	/* store leftover */
+	if (bytes) {
+		for (i = 0; i < bytes; i++)
+			st->buffer[st->leftover + i] = m[i];
+		st->leftover += bytes;
+	}
+}
+
+//stubs for OCaml
+CAMLprim value mc_poly1305_init (value ctx, value key, value off) {
+  poly1305_init ((poly1305_context *) Bytes_val(ctx), _ba_uint8_off(key, off));
+  return Val_unit;
+}
+
+CAMLprim value mc_poly1305_update (value ctx, value buf, value off, value len) {
+  poly1305_update ((poly1305_context *) Bytes_val(ctx), _ba_uint8_off(buf, off), Int_val(len));
+  return Val_unit;
+}
+
+CAMLprim value mc_poly1305_finalize (value ctx, value mac, value off) {
+  poly1305_finish ((poly1305_context *) Bytes_val(ctx), _ba_uint8_off(mac, off));
+  return Val_unit;
+}
+
+CAMLprim value mc_poly1305_ctx_size (__unit ()) {
+  return Val_int(sizeof(poly1305_context));
+}
+
+CAMLprim value mc_poly1305_mac_size (__unit ()) {
+  return Val_int(16);
+}

--- a/src/poly1305.ml
+++ b/src/poly1305.ml
@@ -1,0 +1,57 @@
+module type S = sig
+  type mac = Cstruct.t
+  type 'a iter = 'a Uncommon.iter
+
+  type t
+  val mac_size : int
+
+  val empty : key:Cstruct.t -> t
+  val feed : t -> Cstruct.t -> t
+  val feedi : t -> Cstruct.t iter -> t
+  val get : t -> Cstruct.t
+
+  val mac : key:Cstruct.t -> Cstruct.t -> mac
+  val maci : key:Cstruct.t -> Cstruct.t iter -> mac
+end
+
+module It : S = struct
+  type mac = Cstruct.t
+  type 'a iter = 'a Uncommon.iter
+
+  module P = Native.Poly1305
+  let mac_size = P.mac_size ()
+
+  type t = Native.ctx
+
+  let dup = Bytes.copy
+
+  let empty ~key:{ Cstruct.buffer ; off ; len } =
+    let ctx = Bytes.create (P.ctx_size ()) in
+    if len <> 32 then invalid_arg "Poly1305 key must be 32 bytes" ;
+    P.init ctx buffer off ;
+    ctx
+
+  let update ctx { Cstruct.buffer ; off ; len } =
+    P.update ctx buffer off len
+
+  let feed ctx cs =
+    let t = dup ctx in
+    update t cs ;
+    t
+
+  let feedi ctx iter =
+    let t = dup ctx in
+    iter (update t) ;
+    t
+
+  let final ctx =
+    let res = Cstruct.create mac_size in
+    P.finalize ctx res.buffer res.off;
+    res
+
+  let get ctx = final (dup ctx)
+
+  let mac ~key data = feed (empty ~key) data |> final
+
+  let maci ~key iter = feedi (empty ~key) iter |> final
+end

--- a/tests/test_cipher.ml
+++ b/tests/test_cipher.ml
@@ -638,6 +638,14 @@ let chacha20_cases =
                   "f3ac30ccfb5e14204f5e4268b90a8804")
     ]
 
+let poly1305_rfc8439_2_5_2 _ =
+  let key = vx "85d6be7857556d337f4452fe42d506a80103808afb0db2fd4abff6af4149f51b"
+  and data = Cstruct.of_string "Cryptographic Forum Research Group"
+  and output = vx "a8061dc1305136c6c22b8baf0c0127a9"
+  in
+  assert_cs_equal ~msg:"poly 1305 RFC8439 Section 2.5.2"
+    (Poly1305.mac ~key data) output
+
 let suite = [
   "AES-ECB" >::: [ "SP 300-38A" >::: aes_ecb_cases ] ;
   "AES-CBC" >::: [ "SP 300-38A" >::: aes_cbc_cases ] ;
@@ -647,4 +655,5 @@ let suite = [
   "AES-CCM-REGRESSION" >::: ccm_regressions ;
   "AES-GCM-REGRESSION" >::: gcm_regressions ;
   "Chacha20" >::: chacha20_cases ;
+  "poly1305" >:: poly1305_rfc8439_2_5_2 ;
 ]

--- a/tests/test_cipher.ml
+++ b/tests/test_cipher.ml
@@ -413,6 +413,231 @@ let gcm_regressions =
   ]
 
 
+let chacha20_cases =
+  let case msg ?ctr ~key ~nonce ?(input = Cstruct.create 128) output =
+    let key = vx key
+    and nonce = vx nonce
+    and output = vx output
+    in
+    assert_cs_equal ~msg (Chacha20.crypt ~key ~nonce ?ctr input) output
+  in
+  let rfc8439_test_2_4_2 _ =
+    let key = "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"
+    and nonce = "000000000000004a00000000"
+    and input = Cstruct.of_string "Ladies and Gentlemen of the class of '99: If I could offer you only one tip for the future, sunscreen would be it."
+    and output =
+{|6e 2e 35 9a 25 68 f9 80 41 ba 07 28 dd 0d 69 81
+  e9 7e 7a ec 1d 43 60 c2 0a 27 af cc fd 9f ae 0b
+  f9 1b 65 c5 52 47 33 ab 8f 59 3d ab cd 62 b3 57
+  16 39 d6 24 e6 51 52 ab 8f 53 0c 35 9f 08 61 d8
+  07 ca 0d bf 50 0d 6a 61 56 a3 8e 08 8a 22 b6 5e
+  52 bc 51 4d 16 cc f8 06 81 8c e9 1a b7 79 37 36
+  5a f9 0b bf 74 a3 5b e6 b4 0b 8e ed f2 78 5e 42
+  87 4d|}
+    in
+    case "Chacha20 RFC 8439 2.4.2" ~ctr:1L ~key ~nonce ~input output
+  in
+  (* from https://tools.ietf.org/html/draft-strombergson-chacha-test-vectors-01 *)
+  let case ~key ~nonce ~output0 ~output1 _ =
+    case "chacha20 crypt" ~key ~nonce (output0 ^ output1)
+  in
+  List.map test_case
+    [
+      rfc8439_test_2_4_2 ;
+
+      case
+        ~key:(String.make 64 '0')
+        ~nonce:(String.make 16 '0')
+        ~output0:("76b8e0ada0f13d90405d6ae55386bd28" ^
+                  "bdd219b8a08ded1aa836efcc8b770dc7" ^
+                  "da41597c5157488d7724e03fb8d84a37" ^
+                  "6a43b8f41518a11cc387b669b2ee6586")
+        ~output1:("9f07e7be5551387a98ba977c732d080d" ^
+                  "cb0f29a048e3656912c6533e32ee7aed" ^
+                  "29b721769ce64e43d57133b074d839d5" ^
+                  "31ed1f28510afb45ace10a1f4b794d6f") ;
+
+      case
+        ~key:("01" ^ String.make 62 '0')
+        ~nonce:(String.make 16 '0')
+        ~output0:("c5d30a7ce1ec119378c84f487d775a85" ^
+                  "42f13ece238a9455e8229e888de85bbd" ^
+                  "29eb63d0a17a5b999b52da22be4023eb" ^
+                  "07620a54f6fa6ad8737b71eb0464dac0")
+        ~output1:("10f656e6d1fd55053e50c4875c9930a3" ^
+                  "3f6d0263bd14dfd6ab8c70521c19338b" ^
+                  "2308b95cf8d0bb7d202d2102780ea352" ^
+                  "8f1cb48560f76b20f382b942500fceac") ;
+
+      case
+        ~key:(String.make 64 '0')
+        ~nonce:("01" ^ String.make 14 '0')
+        ~output0:("ef3fdfd6c61578fbf5cf35bd3dd33b80" ^
+                  "09631634d21e42ac33960bd138e50d32" ^
+                  "111e4caf237ee53ca8ad6426194a8854" ^
+                  "5ddc497a0b466e7d6bbdb0041b2f586b")
+        ~output1:("5305e5e44aff19b235936144675efbe4" ^
+                  "409eb7e8e5f1430f5f5836aeb49bb532" ^
+                  "8b017c4b9dc11f8a03863fa803dc71d5" ^
+                  "726b2b6b31aa32708afe5af1d6b69058") ;
+
+      case
+        ~key:(String.make 64 'f')
+        ~nonce:(String.make 16 'f')
+        ~output0:("d9bf3f6bce6ed0b54254557767fb5744" ^
+                  "3dd4778911b606055c39cc25e674b836" ^
+                  "3feabc57fde54f790c52c8ae43240b79" ^
+                  "d49042b777bfd6cb80e931270b7f50eb")
+        ~output1:("5bac2acd86a836c5dc98c116c1217ec3" ^
+                  "1d3a63a9451319f097f3b4d6dab07787" ^
+                  "19477d24d24b403a12241d7cca064f79" ^
+                  "0f1d51ccaff6b1667d4bbca1958c4306") ;
+
+      case
+        ~key:(String.make 64 '5')
+        ~nonce:(String.make 16 '5')
+        ~output0:("bea9411aa453c5434a5ae8c92862f564" ^
+                  "396855a9ea6e22d6d3b50ae1b3663311" ^
+                  "a4a3606c671d605ce16c3aece8e61ea1" ^
+                  "45c59775017bee2fa6f88afc758069f7")
+        ~output1:("e0b8f676e644216f4d2a3422d7fa36c6" ^
+                  "c4931aca950e9da42788e6d0b6d1cd83" ^
+                  "8ef652e97b145b14871eae6c6804c700" ^
+                  "4db5ac2fce4c68c726d004b10fcaba86") ;
+
+      case
+        ~key:(String.make 64 'a')
+        ~nonce:(String.make 16 'a')
+        ~output0:("9aa2a9f656efde5aa7591c5fed4b35ae" ^
+                  "a2895dec7cb4543b9e9f21f5e7bcbcf3" ^
+                  "c43c748a970888f8248393a09d43e0b7" ^
+                  "e164bc4d0b0fb240a2d72115c4808906")
+        ~output1:("72184489440545d021d97ef6b693dfe5" ^
+                  "b2c132d47e6f041c9063651f96b623e6" ^
+                  "2a11999a23b6f7c461b2153026ad5e86" ^
+                  "6a2e597ed07b8401dec63a0934c6b2a9") ;
+
+      case
+        ~key:"00112233445566778899aabbccddeeffffeeddccbbaa99887766554433221100"
+        ~nonce:"0f1e2d3c4b5a6978"
+        ~output0:("9fadf409c00811d00431d67efbd88fba" ^
+                  "59218d5d6708b1d685863fabbb0e961e" ^
+                  "ea480fd6fb532bfd494b215101505742" ^
+                  "3ab60a63fe4f55f7a212e2167ccab931")
+        ~output1:("fbfd29cf7bc1d279eddf25dd316bb884" ^
+                  "3d6edee0bd1ef121d12fa17cbc2c574c" ^
+                  "ccab5e275167b08bd686f8a09df87ec3" ^
+                  "ffb35361b94ebfa13fec0e4889d18da5") ;
+
+      case
+        ~key:"c46ec1b18ce8a878725a37e780dfb7351f68ed2e194c79fbc6aebee1a667975d"
+        ~nonce:"1ada31d5cf688221"
+        ~output0:("f63a89b75c2271f9368816542ba52f06" ^
+                  "ed49241792302b00b5e8f80ae9a473af" ^
+                  "c25b218f519af0fdd406362e8d69de7f" ^
+                  "54c604a6e00f353f110f771bdca8ab92")
+        ~output1:("e5fbc34e60a1d9a9db17345b0a402736" ^
+                  "853bf910b060bdf1f897b6290f01d138" ^
+                  "ae2c4c90225ba9ea14d518f55929dea0" ^
+                  "98ca7a6ccfe61227053c84e49a4a3332") ;
+
+      case
+        ~key:(String.make 32 '0')
+        ~nonce:(String.make 16 '0')
+        ~output0:("89670952608364fd00b2f90936f031c8" ^
+                  "e756e15dba04b8493d00429259b20f46" ^
+                  "cc04f111246b6c2ce066be3bfb32d9aa" ^
+                  "0fddfbc12123d4b9e44f34dca05a103f")
+        ~output1:("6cd135c2878c832b5896b134f6142a9d" ^
+                  "4d8d0d8f1026d20a0a81512cbce6e975" ^
+                  "8a7143d021978022a384141a80cea306" ^
+                  "2f41f67a752e66ad3411984c787e30ad") ;
+
+      case
+        ~key:("01" ^ String.make 30 '0')
+        ~nonce:(String.make 16 '0')
+        ~output0:("ae56060d04f5b597897ff2af1388dbce" ^
+                  "ff5a2a4920335dc17a3cb1b1b10fbe70" ^
+                  "ece8f4864d8c7cdf0076453a8291c7db" ^
+                  "eb3aa9c9d10e8ca36be4449376ed7c42")
+        ~output1:("fc3d471c34a36fbbf616bc0a0e7c5230" ^
+                  "30d944f43ec3e78dd6a12466547cb4f7" ^
+                  "b3cebd0a5005e762e562d1375b7ac445" ^
+                  "93a991b85d1a60fba2035dfaa2a642d5") ;
+
+      case
+        ~key:(String.make 32 '0')
+        ~nonce:("01" ^ String.make 14 '0')
+        ~output0:("1663879eb3f2c9949e2388caa343d361" ^
+                  "bb132771245ae6d027ca9cb010dc1fa7" ^
+                  "178dc41f8278bc1f64b3f12769a24097" ^
+                  "f40d63a86366bdb36ac08abe60c07fe8")
+        ~output1:("b057375c89144408cc744624f69f7f4c" ^
+                  "cbd93366c92fc4dfcada65f1b959d8c6" ^
+                  "4dfc50de711fb46416c2553cc60f21bb" ^
+                  "fd006491cb17888b4fb3521c4fdd8745") ;
+
+      case
+        ~key:(String.make 32 'f')
+        ~nonce:(String.make 16 'f')
+        ~output0:("992947c3966126a0e660a3e95db048de" ^
+                  "091fb9e0185b1e41e41015bb7ee50150" ^
+                  "399e4760b262f9d53f26d8dd19e56f5c" ^
+                  "506ae0c3619fa67fb0c408106d0203ee")
+        ~output1:("40ea3cfa61fa32a2fda8d1238a2135d9" ^
+                  "d4178775240f99007064a6a7f0c731b6" ^
+                  "7c227c52ef796b6bed9f9059ba0614bc" ^
+                  "f6dd6e38917f3b150e576375be50ed67") ;
+
+      case
+        ~key:(String.make 32 '5')
+        ~nonce:(String.make 16 '5')
+        ~output0:("357d7d94f966778f5815a2051dcb0413" ^
+                  "3b26b0ead9f57dd09927837bc3067e4b" ^
+                  "6bf299ad81f7f50c8da83c7810bfc17b" ^
+                  "b6f4813ab6c326957045fd3fd5e19915")
+        ~output1:("ec744a6b9bf8cbdcb36d8b6a5499c68a" ^
+                  "08ef7be6cc1e93f2f5bcd2cad4e47c18" ^
+                  "a3e5d94b5666382c6d130d822dd56aac" ^
+                  "b0f8195278e7b292495f09868ddf12cc") ;
+
+      case
+        ~key:(String.make 32 'a')
+        ~nonce:(String.make 16 'a')
+        ~output0:("fc79acbd58526103862776aab20f3b7d" ^
+                  "8d3149b2fab65766299316b6e5b16684" ^
+                  "de5de548c1b7d083efd9e3052319e0c6" ^
+                  "254141da04a6586df800f64d46b01c87")
+        ~output1:("1f05bc67e07628ebe6f6865a2177e0b6" ^
+                  "6a558aa7cc1e8ff1a98d27f7071f8335" ^
+                  "efce4537bb0ef7b573b32f32765f2900" ^
+                  "7da53bba62e7a44d006f41eb28fe15d6") ;
+
+      case
+        ~key:"00112233445566778899aabbccddeeff"
+        ~nonce:"0f1e2d3c4b5a6978"
+        ~output0:("d1abf630467eb4f67f1cfb47cd626aae" ^
+                  "8afedbbe4ff8fc5fe9cfae307e74ed45" ^
+                  "1f1404425ad2b54569d5f18148939971" ^
+                  "abb8fafc88ce4ac7fe1c3d1f7a1eb7ca")
+        ~output1:("e76ca87b61a9713541497760dd9ae059" ^
+                  "350cad0dcedfaa80a883119a1a6f987f" ^
+                  "d1ce91fd8ee0828034b411200a9745a2" ^
+                  "85554475d12afc04887fef3516d12a2c") ;
+
+      case
+        ~key:"c46ec1b18ce8a878725a37e780dfb735"
+        ~nonce:"1ada31d5cf688221"
+        ~output0:("826abdd84460e2e9349f0ef4af5b179b" ^
+                  "426e4b2d109a9c5bb44000ae51bea90a" ^
+                  "496beeef62a76850ff3f0402c4ddc99f" ^
+                  "6db07f151c1c0dfac2e56565d6289625")
+        ~output1:("5b23132e7b469c7bfb88fa95d44ca5ae" ^
+                  "3e45e848a4108e98bad7a9eb15512784" ^
+                  "a6a9e6e591dce674120acaf9040ff50f" ^
+                  "f3ac30ccfb5e14204f5e4268b90a8804")
+    ]
+
 let suite = [
   "AES-ECB" >::: [ "SP 300-38A" >::: aes_ecb_cases ] ;
   "AES-CBC" >::: [ "SP 300-38A" >::: aes_cbc_cases ] ;
@@ -421,4 +646,5 @@ let suite = [
   "AES-CCM" >::: ccm_cases ;
   "AES-CCM-REGRESSION" >::: ccm_regressions ;
   "AES-GCM-REGRESSION" >::: gcm_regressions ;
+  "Chacha20" >::: chacha20_cases ;
 ]

--- a/xen/dune
+++ b/xen/dune
@@ -7,7 +7,7 @@
  (libraries mirage-xen-posix)
  (c_flags (:standard) (:include ../src/cflags.sexp) (:include cflags-xen.sexp))
  (c_names detect_cpu_features misc misc_sse hash_stubs md5 sha1 sha256 sha512
-          aes_generic aes_aesni des_generic chacha
+          aes_generic aes_aesni des_generic chacha poly1305-donna
           ghash_pclmul ghash_generic ghash_ctmul
           entropy_cpu_stubs)
 )

--- a/xen/dune
+++ b/xen/dune
@@ -7,7 +7,7 @@
  (libraries mirage-xen-posix)
  (c_flags (:standard) (:include ../src/cflags.sexp) (:include cflags-xen.sexp))
  (c_names detect_cpu_features misc misc_sse hash_stubs md5 sha1 sha256 sha512
-          aes_generic aes_aesni des_generic
+          aes_generic aes_aesni des_generic chacha
           ghash_pclmul ghash_generic ghash_ctmul
           entropy_cpu_stubs)
 )


### PR DESCRIPTION
Differences include:
 - OCaml API (no separate expand and encrypt/decrypt),
 - support for IETF mode (nonce 12 bytes, counter 32bit)
 - reduced allocation overhead