### PR TITLE
add ppc64le support

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,5 @@
+* Add support for ppc64le. (@avsm)
+
 ## v0.8.1 (2020-07-02)
 
 * Add Chacha20 implementation (based on abeaumont/ocaml-chacha), supporting

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,6 @@
-* Add support for ppc64le. (@avsm)
+## v0.8.2 (2020-07-25)
+
+* Add support for ppc64le. (#76 @avsm)
 
 ## v0.8.1 (2020-07-02)
 

--- a/src/native/entropy_cpu_stubs.c
+++ b/src/native/entropy_cpu_stubs.c
@@ -82,6 +82,10 @@ CAMLprim value caml_cycle_counter (value __unused(unit)) {
   return Val_long (__rdtsc ());
 #elif defined (__arm__) || defined (__aarch64__)
   return Val_long (read_virtual_count ());
+#elif defined(__powerpc64__)
+    uint64_t rval;
+    __asm__ volatile ("mfspr %0, 268":"=r" (rval));
+    return rval;
 #else
 #error ("No known cycle-counting instruction.")
 #endif

--- a/src/native/ghash_generic.c
+++ b/src/native/ghash_generic.c
@@ -16,7 +16,7 @@
  * !LARGE_TABLES -> 8K per key, ~3x slower. */
 #define __MC_GHASH_LARGE_TABLES
 
-#if defined (__x86_64__) || defined (__aarch64__)
+#if defined (__x86_64__) || defined (__aarch64__) || defined(__powerpc64__)
 
 #define __set_uint128_t(w1, w0) (((__uint128_t) w1 << 64) | w0)
 
@@ -103,4 +103,4 @@ mc_ghash_generic (value m, value hash, value src, value off, value len) {
   return Val_unit;
 }
 
-#endif /* x86_64 || aarch64 */
+#endif /* x86_64 || aarch64 || powerpc64 */

--- a/src/native/poly1305-donna.c
+++ b/src/native/poly1305-donna.c
@@ -7,7 +7,7 @@ typedef struct poly1305_context {
         unsigned char opaque[136];
 } poly1305_context;
 
-#if defined (__x86_64__) || defined (__aarch64__)
+#if defined (__x86_64__) || defined (__aarch64__) || defined(__powerpc64__)
 #include "poly1305-donna-64.h"
 #else
 #include "poly1305-donna-32.h"


### PR DESCRIPTION
Implementation of rtdsc based on clang's builtin version and from gperftools at https://chromium.googlesource.com/external/gperftools/+/master/src/base/cycleclock.h

Fixes #75

Just testing this on the ocaml-ci first so that we can have ppc64 CI before undrafting this.