### PR TITLE
Namespace `poly1305_init` to `mcrypto_poly1305_init` in header files

### DIFF
--- a/src/native/poly1305-donna-32.h
+++ b/src/native/poly1305-donna-32.h
@@ -44,7 +44,7 @@ U32TO8(unsigned char *p, unsigned long v) {
 }
 
 void
-poly1305_init(poly1305_context *ctx, const unsigned char key[32]) {
+mcrypto_poly1305_init(poly1305_context *ctx, const unsigned char key[32]) {
 	poly1305_state_internal_t *st = (poly1305_state_internal_t *)ctx;
 
 	/* r &= 0xffffffc0ffffffc0ffffffc0fffffff */

--- a/src/native/poly1305-donna-64.h
+++ b/src/native/poly1305-donna-64.h
@@ -53,7 +53,7 @@ U64TO8(unsigned char *p, unsigned long long v) {
 }
 
 void
-poly1305_init(poly1305_context *ctx, const unsigned char key[32]) {
+mcrypto_poly1305_init(poly1305_context *ctx, const unsigned char key[32]) {
 	poly1305_state_internal_t *st = (poly1305_state_internal_t *)ctx;
 	unsigned long long t0,t1;
 

--- a/src/native/poly1305-donna.c
+++ b/src/native/poly1305-donna.c
@@ -52,7 +52,7 @@ poly1305_update(poly1305_context *ctx, const unsigned char *m, size_t bytes) {
 
 //stubs for OCaml
 CAMLprim value mc_poly1305_init (value ctx, value key, value off) {
-  poly1305_init ((poly1305_context *) Bytes_val(ctx), _ba_uint8_off(key, off));
+  mcrypto_poly1305_init ((poly1305_context *) Bytes_val(ctx), _ba_uint8_off(key, off));
   return Val_unit;
 }
 


### PR DESCRIPTION
Linking mirage-crypto in a project with OpenSSL (and thus, `lcrypto`), resulted in the following error:

```
x86_64-unknown-linux-musl-ld: openssl-1.1.1g-x86_64-unknown-linux-musl/lib/libcrypto.a(poly1305-x86_64.o): in function `poly1305_init':
/build/openssl-1.1.1g/crypto/poly1305/poly1305-x86_64.s:16: multiple definition of `poly1305_init';
  mirage-crypto-0.8.1-x86_64-unknown-linux-musl/libmirage_crypto_stubs.a(poly1305-donna.o):(.text+0x140): first defined here
collect2: error: ld returned 1 exit status
File "caml_startup", line 1:
Error: Error during linking
```