### PR TITLE
new test_entropy: testing bootstrap function and timer (cycle counter) to not produce the same output on two subsequent calls

### DIFF
--- a/rng/entropy.ml
+++ b/rng/entropy.ml
@@ -29,10 +29,10 @@
 
 module Cpu_native = struct
 
-  external cycles : unit -> int  = "caml_cycle_counter" [@@noalloc]
-  external rdseed : unit -> int  = "caml_cpu_rdseed" [@@noalloc]
-  external rdrand : unit -> int  = "caml_cpu_rdrand" [@@noalloc]
-  external rng_type : unit -> int  = "caml_cpu_rng_type" [@@noalloc]
+  external cycles : unit -> int  = "mc_cycle_counter" [@@noalloc]
+  external rdseed : unit -> int  = "mc_cpu_rdseed" [@@noalloc]
+  external rdrand : unit -> int  = "mc_cpu_rdrand" [@@noalloc]
+  external rng_type : unit -> int  = "mc_cpu_rng_type" [@@noalloc]
 
   let cpu_rng =
     match rng_type () with

--- a/rng/mirage_crypto_rng.mli
+++ b/rng/mirage_crypto_rng.mli
@@ -96,11 +96,11 @@ module Entropy : sig
   (** {1 Timer source} *)
 
   val interrupt_hook : unit -> unit -> Cstruct.t
-  (** [interrupt_hook ()] collects the lower 4 bytes from [rdtsc], to be
+  (** [interrupt_hook ()] collects lower bytes from the cycle counter, to be
       used for entropy collection in the event loop. *)
 
   val timer_accumulator : g option -> unit -> unit
-  (** [timer_accumulator g] is the accumulator for the [`Timer] source,
+  (** [timer_accumulator g] is the accumulator for the timer source,
       applying {!interrupt_hook} on each call. *)
 
   (** {1 Periodic pulled sources} *)

--- a/src/native.ml
+++ b/src/native.ml
@@ -104,7 +104,7 @@ external blit : buffer -> off -> buffer -> off -> size -> unit = "caml_blit_bigs
 external misc_mode : unit -> int = "mc_misc_mode" [@@noalloc]
 
 external _detect_cpu_features : unit -> unit = "mc_detect_cpu_features" [@@noalloc]
-external _detect_entropy : unit -> unit = "caml_entropy_detect"
+external _detect_entropy : unit -> unit = "mc_entropy_detect"
 
 let () =
   _detect_cpu_features ();

--- a/src/native/entropy_cpu_stubs.c
+++ b/src/native/entropy_cpu_stubs.c
@@ -55,7 +55,7 @@ static inline uint64_t read_cycle_counter(void)
 }
 #endif
 
-CAMLprim value caml_cycle_counter (value __unused(unit)) {
+CAMLprim value mc_cycle_counter (value __unused(unit)) {
 #if defined (__i386__) || defined (__x86_64__)
   return Val_long (__rdtsc ());
 #elif defined (__arm__) || defined (__aarch64__)
@@ -101,7 +101,7 @@ static void detect () {
 #endif
 }
 
-CAMLprim value caml_cpu_rdseed (value __unused(unit)) {
+CAMLprim value mc_cpu_rdseed (value __unused(unit)) {
 #ifdef __mc_ENTROPY__
   random_t r = 0;
   int ok = 0;
@@ -114,7 +114,7 @@ CAMLprim value caml_cpu_rdseed (value __unused(unit)) {
 #endif
 }
 
-CAMLprim value caml_cpu_rdrand (value __unused(unit)) {
+CAMLprim value mc_cpu_rdrand (value __unused(unit)) {
 #ifdef __mc_ENTROPY__
   random_t r = 0;
   int ok = 0;
@@ -127,11 +127,11 @@ CAMLprim value caml_cpu_rdrand (value __unused(unit)) {
 #endif
 }
 
-CAMLprim value caml_cpu_rng_type (value __unused(unit)) {
+CAMLprim value mc_cpu_rng_type (value __unused(unit)) {
   return Val_int (__cpu_rng);
 }
 
-CAMLprim value caml_entropy_detect (value __unused(unit)) {
+CAMLprim value mc_entropy_detect (value __unused(unit)) {
   detect ();
   return Val_unit;
 }

--- a/src/native/poly1305-donna-32.h
+++ b/src/native/poly1305-donna-32.h
@@ -43,7 +43,7 @@ U32TO8(unsigned char *p, unsigned long v) {
 	p[3] = (v >> 24) & 0xff;
 }
 
-void
+static void
 poly1305_init(poly1305_context *ctx, const unsigned char key[32]) {
 	poly1305_state_internal_t *st = (poly1305_state_internal_t *)ctx;
 
@@ -132,7 +132,7 @@ poly1305_blocks(poly1305_state_internal_t *st, const unsigned char *m, size_t by
 	st->h[4] = h4;
 }
 
-POLY1305_NOINLINE void
+POLY1305_NOINLINE static void
 poly1305_finish(poly1305_context *ctx, unsigned char mac[16]) {
 	poly1305_state_internal_t *st = (poly1305_state_internal_t *)ctx;
 	unsigned long h0,h1,h2,h3,h4,c;

--- a/src/native/poly1305-donna-64.h
+++ b/src/native/poly1305-donna-64.h
@@ -52,7 +52,7 @@ U64TO8(unsigned char *p, unsigned long long v) {
 	p[7] = (v >> 56) & 0xff;
 }
 
-void
+static void
 poly1305_init(poly1305_context *ctx, const unsigned char key[32]) {
 	poly1305_state_internal_t *st = (poly1305_state_internal_t *)ctx;
 	unsigned long long t0,t1;
@@ -131,7 +131,7 @@ poly1305_blocks(poly1305_state_internal_t *st, const unsigned char *m, size_t by
 }
 
 
-POLY1305_NOINLINE void
+POLY1305_NOINLINE static void
 poly1305_finish(poly1305_context *ctx, unsigned char mac[16]) {
 	poly1305_state_internal_t *st = (poly1305_state_internal_t *)ctx;
 	unsigned long long h0,h1,h2,c;

--- a/src/native/poly1305-donna.c
+++ b/src/native/poly1305-donna.c
@@ -13,7 +13,7 @@ typedef struct poly1305_context {
 #include "poly1305-donna-32.h"
 #endif
 
-void
+static void
 poly1305_update(poly1305_context *ctx, const unsigned char *m, size_t bytes) {
 	poly1305_state_internal_t *st = (poly1305_state_internal_t *)ctx;
 	size_t i;

--- a/tests/dune
+++ b/tests/dune
@@ -28,7 +28,13 @@
  (modules test_numeric test_dh test_dsa test_rsa test_pk_runner))
 
 (test
- (name test_entropy)
- (modules test_entropy)
+ (name test_entropy_collection)
+ (modules test_entropy_collection)
  (package mirage-crypto-rng-mirage)
  (libraries mirage-crypto-rng-mirage mirage-unix mirage-time-unix mirage-clock-unix))
+
+(test
+ (name test_entropy)
+ (modules test_entropy)
+ (package mirage-crypto-rng)
+ (libraries mirage-crypto-rng))

--- a/tests/test_entropy_collection.ml
+++ b/tests/test_entropy_collection.ml
@@ -1,0 +1,38 @@
+open Lwt.Infix
+
+module Printing_rng = struct
+  type g = unit
+
+  let block = 16
+
+  let create ?time:_ () = ()
+
+  let generate ~g:_ _n = assert false
+
+  let reseed ~g:_ data =
+    Format.printf "reseeding: %a@.%!" Cstruct.hexdump_pp data
+
+  let accumulate ~g:_ source =
+    let print data =
+      Format.printf "accumulate: (src: %a) %a@.%!"
+        Mirage_crypto_rng.Entropy.pp_source source Cstruct.hexdump_pp data
+    in
+    `Acc print
+
+  let seeded ~g:_ = true
+  let pools = 1
+end
+
+module E = Mirage_crypto_rng_mirage.Make(Time)(Mclock)
+
+let with_entropy act =
+  E.initialize (module Printing_rng) >>= fun () ->
+  Format.printf "entropy sources: %a@,%!"
+    (fun ppf -> List.iter (fun x ->
+         Mirage_crypto_rng.Entropy.pp_source ppf x;
+         Format.pp_print_space ppf ()))
+    (Mirage_crypto_rng.Entropy.sources ());
+  act ()
+
+let () =
+  OS.(Main.run (with_entropy (fun () -> Time.sleep_ns 1_000L)))


### PR DESCRIPTION
- use `Val_long` in cycle_counter on powerpc64
- mark poly1305 functions static (alternate fix for #77)