### PR TITLE
mirage-crypto: chacha20 avoid accessing memory which is not mapped

### DIFF
--- a/src/chacha20.ml
+++ b/src/chacha20.ml
@@ -47,9 +47,15 @@ let crypt ~key ~nonce ?(ctr = 0L) data =
   let l = Cstruct.len data in
   let block_count = l // block in
   let len = block * block_count in
+  let last_len =
+    let last = l mod block in
+    if last = 0 then block else last
+  in
   let key_stream = Cstruct.create_unsafe len in
   let rec loop i = function
-    | 0 -> ()
+    | 1 ->
+      chacha20_block state i key_stream ;
+      Native.xor_into data.buffer (data.off + i) key_stream.buffer i last_len
     | n ->
       chacha20_block state i key_stream ;
       Native.xor_into data.buffer (data.off + i) key_stream.buffer i block ;


### PR DESCRIPTION
this avoid accessing memory which is not necessarily ours. without this fix, segmentation faults may be triggered.

the issue if the encrypted data is not of block size (=64 byte), processing the last buffer will access up to 63 byte of memory which is not properly mapped.

bug is present since introduction of chacha20 in 0.8.1.