### PR TITLE
travis: disable testrun on arm64 with depopts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,6 @@ jobs:
     env: OCAML_VERSION=4.10
   - name: OCaml 4.09 with freestanding on arm64
     arch: arm64
-    env: OCAML_VERSION=4.09 DEPOPTS="zarith-freestanding ocaml-freestanding"
+    env: OCAML_VERSION=4.09 DEPOPTS="zarith-freestanding ocaml-freestanding" TESTS=false
 notifications:
   email: false


### PR DESCRIPTION
The actual issue is that zarith-freestanding which modifies the META file of zarith are not properly removed (the opam checksum seems to use modification times, and this changes for the reasons above). Thus, the `opam remove zarith` step fails, and the subsequent `opam install zarith` errors with "already installed" (since the META file for zarith is present).

The actual fix would be to get rid of our hacked together zarith "cross-compilation" schemes, which eventually will be a topic once zarith switched to dune as build system and MirageOS 4 is in shape.