### PR TITLE
mirage-crypto-rng-async

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,10 +31,31 @@ jobs:
           opam pin add -n mirage-crypto-rng-async.dev .
           opam pin add -n mirage-crypto-pk.dev .
           opam depext -y mirage-crypto mirage-crypto-rng mirage-crypto-rng-mirage mirage-crypto-pk
-          opam install -t --best-effort --deps-only .
+          for x in mirage-crypto mirage-crypto-rng mirage-crypto-rng-mirage mirage-crypto-rng-async mirage-crypto-pk; do
+            opam install --dry-run $x > /dev/null
+            if [ $? -eq 0 ]; then
+              opam install -t --deps-only $x
+            fi
+          done
 
       - name: Build
-        run: opam exec -- dune build
+        run: |
+          pkg="mirage-crypto"
+          for x in mirage-crypto-rng mirage-crypto-rng-mirage mirage-crypto-rng-async mirage-crypto-pk; do
+            opam install --dry-run $x > /dev/null
+            if [ $? -eq 0 ]; then
+              pkg=$(echo "$pkg,$x")
+            fi
+          done
+          opam exec -- dune build -p $pkg
 
       - name: Test
-        run: opam exec -- dune runtest
+        run: |
+          pkg="mirage-crypto"
+          for x in mirage-crypto-rng mirage-crypto-rng-mirage mirage-crypto-rng-async mirage-crypto-pk; do
+            opam install --dry-run $x > /dev/null
+            if [ $? -eq 0 ]; then
+              pkg=$(echo "$pkg,$x")
+            fi
+          done
+          opam exec -- dune runtest -p $pkg

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,9 +28,10 @@ jobs:
           opam pin add -n mirage-crypto.dev .
           opam pin add -n mirage-crypto-rng.dev .
           opam pin add -n mirage-crypto-rng-mirage.dev .
+          opam pin add -n mirage-crypto-rng-async.dev .
           opam pin add -n mirage-crypto-pk.dev .
-          opam depext -y mirage-crypto mirage-crypto-rng mirage-crypto-rng-mirage mirage-crypto-pk
-          opam install -t --deps-only .
+          opam depext -y mirage-crypto mirage-crypto-rng mirage-crypto-rng-mirage mirage-crypto-rng-async mirage-crypto-pk
+          opam install -t --best-effort --deps-only .
 
       - name: Build
         run: opam exec -- dune build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
           opam pin add -n mirage-crypto-rng-mirage.dev .
           opam pin add -n mirage-crypto-rng-async.dev .
           opam pin add -n mirage-crypto-pk.dev .
-          opam depext -y mirage-crypto mirage-crypto-rng mirage-crypto-rng-mirage mirage-crypto-rng-async mirage-crypto-pk
+          opam depext -y mirage-crypto mirage-crypto-rng mirage-crypto-rng-mirage mirage-crypto-pk
           opam install -t --best-effort --deps-only .
 
       - name: Build

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         ocaml-version: ["4.11.1", "4.10.1", "4.09.0", "4.08.1"]
-        operating-system: [macos-latest, ubuntu-latest]
+        operating-system: [windows-latest]
 
     runs-on: ${{ matrix.operating-system }}
 
@@ -28,13 +28,12 @@ jobs:
           opam pin add -n mirage-crypto.dev .
           opam pin add -n mirage-crypto-rng.dev .
           opam pin add -n mirage-crypto-rng-mirage.dev .
-          opam pin add -n mirage-crypto-rng-async.dev .
           opam pin add -n mirage-crypto-pk.dev .
           opam depext -y mirage-crypto mirage-crypto-rng mirage-crypto-rng-mirage mirage-crypto-pk
-          opam install -t --deps-only .
+          opam install -t --deps-only mirage-crypto mirage-crypto-rng mirage-crypto-rng-mirage mirage-crypto-pk
 
       - name: Build
-        run: opam exec -- dune build
+        run: opam exec -- dune build -p mirage-crypto,mirage-crypto-rng,mirage-crypto-rng-mirage,mirage-crypto-pk
 
       - name: Test
-        run: opam exec -- dune runtest
+        run: opam exec -- dune runtest -p mirage-crypto,mirage-crypto-rng,mirage-crypto-rng-mirage,mirage-crypto-pk

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ services:
 os: linux
 env:
   global:
-    - PINS="mirage-crypto:. mirage-crypto-rng:. mirage-crypto-rng-mirage:. mirage-crypto-pk:."
+    - PINS="mirage-crypto:. mirage-crypto-rng:. mirage-crypto-rng-mirage:. mirage-crypto-pk:. mirage-crypto-rng-async:."
     - PACKAGE="mirage-crypto-pk"
     - TESTS=true
     - DISTRO=alpine

--- a/mirage-crypto-rng-async.opam
+++ b/mirage-crypto-rng-async.opam
@@ -16,12 +16,12 @@ depends: [
   "ocaml" {>= "4.08.0"}
   "dune" {>= "2.6"}
   "dune-configurator" {>= "2.0.0"}
-  "async" 
+  "async"
   "logs"
   "mirage-crypto"
   "mirage-crypto-rng"
 ]
-conflicts: [ "mirage-runtime" {< "3.8.0"} ]
+available: os != "win32"
 description: """
 
 Mirage-crypto-rng-async feeds the entropy source for Mirage_crypto_rng-based

--- a/mirage-crypto-rng-async.opam
+++ b/mirage-crypto-rng-async.opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+homepage:     "https://github.com/mirage/mirage-crypto"
+dev-repo:     "git+https://github.com/mirage/mirage-crypto.git"
+bug-reports:  "https://github.com/mirage/mirage-crypto/issues"
+doc:          "https://mirage.github.io/mirage-crypto/doc"
+authors:      ["David Kaloper <dk505@cam.ac.uk>" "Hannes Mehnert <hannes@mehnert.org>" ]
+maintainer:   "Hannes Mehnert <hannes@mehnert.org>"
+license:      "ISC"
+synopsis:     "Feed the entropy source in an Async-friendly way"
+
+build: [ ["dune" "subst"] {pinned}
+         ["dune" "build" "-p" name "-j" jobs ]
+         ["dune" "runtest" "-p" name "-j" jobs] {with-test} ]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.6"}
+  "dune-configurator" {>= "2.0.0"}
+  "async" 
+  "logs"
+  "mirage-crypto" {=version}
+]
+conflicts: [ "mirage-runtime" {< "3.8.0"} ]
+description: """
+
+Mirage-crypto-rng-async feeds the entropy source for Mirage_crypto_rng-based
+random number genreator implementations, in an Async-friendly way.
+"""
+

--- a/mirage-crypto-rng-async.opam
+++ b/mirage-crypto-rng-async.opam
@@ -19,6 +19,7 @@ depends: [
   "async" 
   "logs"
   "mirage-crypto"
+  "mirage-crypto-rng"
 ]
 conflicts: [ "mirage-runtime" {< "3.8.0"} ]
 description: """

--- a/mirage-crypto-rng-async.opam
+++ b/mirage-crypto-rng-async.opam
@@ -18,7 +18,7 @@ depends: [
   "dune-configurator" {>= "2.0.0"}
   "async" 
   "logs"
-  "mirage-crypto" {=version}
+  "mirage-crypto"
 ]
 conflicts: [ "mirage-runtime" {< "3.8.0"} ]
 description: """

--- a/rng/async/dune
+++ b/rng/async/dune
@@ -2,6 +2,4 @@
  (name mirage_crypto_rng_async)
  (public_name mirage-crypto-rng-async)
  (modules mirage_crypto_rng_async)
- (libraries async mirage-crypto-rng mirage-crypto-rng.unix logs)
- (enabled_if
-  (<> %{os_type} "Win32")))
+ (libraries async mirage-crypto-rng mirage-crypto-rng.unix logs))

--- a/rng/async/dune
+++ b/rng/async/dune
@@ -1,0 +1,6 @@
+(library
+ (name mirage_crypto_rng_async)
+ (public_name mirage-crypto-rng-async)
+ (modules mirage_crypto_rng_async)
+ (libraries async mirage-crypto-rng mirage-crypto-rng.unix logs))
+

--- a/rng/async/dune
+++ b/rng/async/dune
@@ -2,5 +2,5 @@
  (name mirage_crypto_rng_async)
  (public_name mirage-crypto-rng-async)
  (modules mirage_crypto_rng_async)
- (libraries async mirage-crypto-rng mirage-crypto-rng.unix logs))
-
+ (libraries async mirage-crypto-rng mirage-crypto-rng.unix logs)
+ (enabled_if (<> %{os_type} "Win32")))

--- a/rng/async/dune
+++ b/rng/async/dune
@@ -3,4 +3,5 @@
  (public_name mirage-crypto-rng-async)
  (modules mirage_crypto_rng_async)
  (libraries async mirage-crypto-rng mirage-crypto-rng.unix logs)
- (enabled_if (<> %{os_type} "Win32")))
+ (enabled_if
+  (<> %{os_type} "Win32")))

--- a/rng/async/mirage_crypto_rng_async.ml
+++ b/rng/async/mirage_crypto_rng_async.ml
@@ -1,0 +1,88 @@
+open Core
+open Async
+
+open Mirage_crypto_rng
+
+let src = Logs.Src.create "mirage-crypto-rng-async" ~doc:"Mirage crypto RNG Async"
+module Log = (val Logs.src_log src : Logs.LOG)
+
+let running = ref false
+
+let ns_since_epoch time_source () =
+  Synchronous_time_source.now time_source
+  |> Time_ns.to_int_ns_since_epoch
+  |> Int64.of_int
+;;
+
+let periodically_collect_cpu_entropy time_source span =
+  Synchronous_time_source.run_at_intervals
+    time_source
+    span
+    (fun () -> Entropy.cpu_rng None);
+;;
+
+let periodically_collect_getrandom_entropy time_source span =
+  let source = Entropy.register_source "getrandom" in
+  Synchronous_time_source.run_at_intervals
+    time_source
+    span
+    (fun () ->
+      let per_pool = 8 in
+      let size = per_pool * pools None in
+      (* Might block so run it in a thread. *)
+      In_thread.run (fun () -> Mirage_crypto_rng_unix.getrandom size)
+      >>> fun random ->
+        let idx = ref 0 in
+        let f () = 
+          incr idx;
+          Cstruct.sub random (per_pool * (pred !idx)) per_pool
+        in
+        Entropy.feed_pools None source f)
+;;
+
+let read_cpu_counter_at_the_start_of_every_cycle () =
+  Scheduler.Expert.run_every_cycle_start (fun () ->
+    Entropy.timer_accumulator None ())
+;;
+
+let getrandom_init i =
+  let data = Mirage_crypto_rng_unix.getrandom 128 in
+  Entropy.header i data
+;;
+
+let initialize ?time_source ?(sleep = Time_ns.Span.of_int_sec 1) () =
+  let time_source =
+    Option.value ~default:(Synchronous_time_source.wall_clock ()) time_source
+  in
+  if !running then
+    Log.debug
+      (fun m -> m "Mirage_crypto_rng_lwt.initialize has already been called, \
+                   ignoring this call.")
+  else begin
+    (try
+       let _ = default_generator () in
+       Log.warn (fun m -> m "Mirage_crypto_rng.default_generator has already \
+                             been set (but not via \
+                             Mirage_crypto_rng_lwt.initialize). Please check \
+                             that this is intentional");
+     with
+       No_default_generator -> ());
+    running := true;
+    let seed =
+      (* getrandom_init might block, but this is initialization so prima facie, it
+         doesn't matter. *)
+      let init =
+        Entropy.[ bootstrap ; whirlwind_bootstrap ; bootstrap ; getrandom_init ]
+      in
+      List.mapi ~f:(fun i f -> f i) init |> Cstruct.concat
+    in
+    let rng = 
+      create ~seed ~time:(ns_since_epoch time_source) (module Fortuna) 
+    in
+    set_default_generator rng;
+    periodically_collect_cpu_entropy time_source sleep;
+    periodically_collect_getrandom_entropy 
+      time_source 
+      (Time_ns.Span.scale_int sleep 10);
+    read_cpu_counter_at_the_start_of_every_cycle ();
+  end

--- a/rng/async/mirage_crypto_rng_async.ml
+++ b/rng/async/mirage_crypto_rng_async.ml
@@ -56,7 +56,7 @@ let initialize ?g ?time_source ?(sleep = Time_ns.Span.of_int_sec 1) generator =
        let _ = default_generator () in
        Log.warn (fun m -> m "Mirage_crypto_rng.default_generator has already \
                              been set (but not via \
-                             Mirage_crypto_rng_lwt.initialize). Please check \
+                             Mirage_crypto_rng_async.initialize). Please check \
                              that this is intentional");
      with
        No_default_generator -> ());

--- a/rng/async/mirage_crypto_rng_async.ml
+++ b/rng/async/mirage_crypto_rng_async.ml
@@ -12,14 +12,12 @@ let ns_since_epoch time_source () =
   Synchronous_time_source.now time_source
   |> Time_ns.to_int_ns_since_epoch
   |> Int64.of_int
-;;
 
 let periodically_collect_cpu_entropy time_source span =
   Synchronous_time_source.run_at_intervals
     time_source
     span
-    (fun () -> Entropy.cpu_rng None);
-;;
+    (fun () -> Entropy.cpu_rng None)
 
 let periodically_collect_getrandom_entropy time_source span =
   let source = Entropy.register_source "getrandom" in
@@ -38,17 +36,14 @@ let periodically_collect_getrandom_entropy time_source span =
           Cstruct.sub random (per_pool * (pred !idx)) per_pool
         in
         Entropy.feed_pools None source f)
-;;
 
 let read_cpu_counter_at_the_start_of_every_cycle () =
   Scheduler.Expert.run_every_cycle_start (fun () ->
     Entropy.timer_accumulator None ())
-;;
 
 let getrandom_init i =
   let data = Mirage_crypto_rng_unix.getrandom 128 in
   Entropy.header i data
-;;
 
 let initialize ?time_source ?(sleep = Time_ns.Span.of_int_sec 1) () =
   let time_source =

--- a/rng/async/mirage_crypto_rng_async.ml
+++ b/rng/async/mirage_crypto_rng_async.ml
@@ -27,15 +27,13 @@ let periodically_collect_getrandom_entropy time_source span =
     (fun () ->
       let per_pool = 8 in
       let size = per_pool * pools None in
-      (* Might block so run it in a thread. *)
-      In_thread.run (fun () -> Mirage_crypto_rng_unix.getrandom size)
-      >>> fun random ->
-        let idx = ref 0 in
-        let f () = 
-          incr idx;
-          Cstruct.sub random (per_pool * (pred !idx)) per_pool
-        in
-        Entropy.feed_pools None source f)
+      let random = Mirage_crypto_rng_unix.getrandom size in
+      let idx = ref 0 in
+      let f () =
+        incr idx;
+        Cstruct.sub random (per_pool * (pred !idx)) per_pool
+      in
+      Entropy.feed_pools None source f)
 
 let read_cpu_counter_at_the_start_of_every_cycle () =
   Scheduler.Expert.run_every_cycle_start (fun () ->

--- a/rng/async/mirage_crypto_rng_async.ml
+++ b/rng/async/mirage_crypto_rng_async.ml
@@ -49,7 +49,7 @@ let initialize ?g ?time_source ?(sleep = Time_ns.Span.of_int_sec 1) generator =
   in
   if !running then
     Log.debug
-      (fun m -> m "Mirage_crypto_rng_lwt.initialize has already been called, \
+      (fun m -> m "Mirage_crypto_rng_async.initialize has already been called, \
                    ignoring this call.")
   else begin
     (try

--- a/rng/async/mirage_crypto_rng_async.mli
+++ b/rng/async/mirage_crypto_rng_async.mli
@@ -6,13 +6,13 @@ open! Async
     This module initializes a Fortuna RNG with [getrandom()], and CPU RNG.
 *)
 
-(** [initialize ~sleep ()] will bring the RNG into a working state. The argument
-    [sleep] is measured in ns (default 1s), and used to sleep between collection
-    of entropy from the CPU RNG, every [10 * sleep] getrandom is used to collect
-    entropy.
-*)
-val initialize 
-  :  ?time_source:Synchronous_time_source.t 
-  -> ?sleep:Time_ns.Span.t 
-  -> unit 
+(** [initialize ~sleep generator] will bring the RNG into a working state. The
+    argument [sleep] is measured in ns (default 1s), and used to sleep between
+    collection of entropy from the CPU RNG, every [10 * sleep] getrandom is used
+    to collect entropy.  *)
+val initialize
+  :  ?g:'a
+  -> ?time_source:Synchronous_time_source.t
+  -> ?sleep:Time_ns.Span.t
+  -> 'a Mirage_crypto_rng.generator
   -> unit

--- a/rng/async/mirage_crypto_rng_async.mli
+++ b/rng/async/mirage_crypto_rng_async.mli
@@ -1,0 +1,18 @@
+open! Core
+open! Async
+
+(** {b RNG} seeding on {b Async}.
+
+    This module initializes a Fortuna RNG with [getrandom()], and CPU RNG.
+*)
+
+(** [initialize ~sleep ()] will bring the RNG into a working state. The argument
+    [sleep] is measured in ns (default 1s), and used to sleep between collection
+    of entropy from the CPU RNG, every [10 * sleep] getrandom is used to collect
+    entropy.
+*)
+val initialize 
+  :  ?time_source:Synchronous_time_source.t 
+  -> ?sleep:Time_ns.Span.t 
+  -> unit 
+  -> unit

--- a/tests/dune
+++ b/tests/dune
@@ -38,6 +38,12 @@
    mirage-clock-unix))
 
 (test
+ (name test_entropy_collection_async)
+ (modules test_entropy_collection_async)
+ (package mirage-crypto-rng-async)
+ (libraries mirage-crypto-rng-async))
+
+(test
  (name test_entropy)
  (modules test_entropy)
  (package mirage-crypto-rng)

--- a/tests/test_entropy_collection_async.ml
+++ b/tests/test_entropy_collection_async.ml
@@ -1,0 +1,44 @@
+open Core
+open Async
+
+module Printing_rng = struct
+  type g = unit
+
+  let block = 16
+
+  let create ?time:_ () = ()
+
+  let generate ~g:_ _n = assert false
+
+  let reseed ~g:_ data =
+    Format.printf "reseeding: %a@.%!" Cstruct.hexdump_pp data
+
+  let accumulate ~g:_ source =
+    let print data =
+      Format.printf "accumulate: (src: %a) %a@.%!"
+        Mirage_crypto_rng.Entropy.pp_source source Cstruct.hexdump_pp data
+    in
+    `Acc print
+
+  let seeded ~g:_ = true
+  let pools = 1
+end
+
+module E = Mirage_crypto_rng_async
+
+
+let main () =
+  E.initialize (module Printing_rng);
+  Format.printf "entropy sources: %a@,%!"
+    (fun ppf -> List.iter ~f:(fun x ->
+         Mirage_crypto_rng.Entropy.pp_source ppf x;
+         Format.pp_print_space ppf ()))
+    (Mirage_crypto_rng.Entropy.sources ());
+  don't_wait_for (
+    Time_source.after
+      (Time_source.wall_clock ())
+      (Time_ns.Span.of_int_sec 10)
+    >>= fun () ->
+    Shutdown.exit 0)
+
+let () = ignore (Scheduler.go_main ~main () : never_returns)


### PR DESCRIPTION
This is an implementation of the async-analogue of `Mirage_crypto_rng_lwt`. It's exposes a single `initialize` function that schedules several periodic jobs to collect entropy from the system and feed it into the `Entropy` module for use by the PRNGs.

I haven't tested this yet, but wanted to throw this up here to gauge whether this would be a welcome contribution. If this looks good, I will follow it up with getting @dinosaure's async ocaml-tls implementation into a state where it can be merged into that project as well.