### PR TITLE
require client code to match on cpu_rng support

### DIFF
--- a/mirage-crypto-rng-mirage.opam
+++ b/mirage-crypto-rng-mirage.opam
@@ -18,6 +18,8 @@ depends: [
   "mirage-crypto-rng" {=version}
   "duration"
   "cstruct" {>= "4.0.0"}
+  "logs"
+  "lwt" {>= "4.0.0"}
   "mirage-runtime" {>= "3.8.0"}
   "mirage-time" {>= "2.0.0"}
   "mirage-clock" {>= "3.0.0"}

--- a/rng/async/mirage_crypto_rng_async.ml
+++ b/rng/async/mirage_crypto_rng_async.ml
@@ -14,10 +14,13 @@ let ns_since_epoch time_source () =
   |> Int64.of_int
 
 let periodically_collect_cpu_entropy time_source span =
-  Synchronous_time_source.run_at_intervals
-    time_source
-    span
-    (Entropy.cpu_rng None)
+  match Entropy.cpu_rng with
+  | Error `Not_supported -> ()
+  | Ok cpu_rng ->
+    Synchronous_time_source.run_at_intervals
+      time_source
+      span
+      (cpu_rng None)
 
 let periodically_collect_getrandom_entropy time_source span =
   let source = Entropy.register_source "getrandom" in

--- a/rng/lwt/mirage_crypto_rng_lwt.ml
+++ b/rng/lwt/mirage_crypto_rng_lwt.ml
@@ -26,7 +26,9 @@ let getrandom_task delta source =
   periodic task delta
 
 let rdrand_task delta =
-  periodic (Entropy.cpu_rng None) delta
+  match Entropy.cpu_rng with
+  | Error `Not_supported -> ()
+  | Ok cpu_rng -> periodic (cpu_rng None) delta
 
 let running = ref false
 

--- a/rng/mirage/mirage_crypto_rng_mirage.ml
+++ b/rng/mirage/mirage_crypto_rng_mirage.ml
@@ -33,15 +33,18 @@ module Log = (val Logs.src_log src : Logs.LOG)
 
 module Make (T : Mirage_time.S) (M : Mirage_clock.MCLOCK) = struct
   let rdrand_task g delta =
-    let open Lwt.Infix in
-    let rdrand = Entropy.cpu_rng g in
-    Lwt.async (fun () ->
-        let rec one () =
-          rdrand ();
-          T.sleep_ns delta >>=
-          one
-        in
-        one ())
+    match Entropy.cpu_rng with
+    | Error `Not_supported -> ()
+    | Ok cpu_rng ->
+      let open Lwt.Infix in
+      let rdrand = cpu_rng g in
+      Lwt.async (fun () ->
+          let rec one () =
+            rdrand ();
+            T.sleep_ns delta >>=
+            one
+          in
+          one ())
 
   let bootstrap_functions () =
     [ Entropy.bootstrap ; Entropy.bootstrap ;

--- a/rng/mirage_crypto_rng.mli
+++ b/rng/mirage_crypto_rng.mli
@@ -84,7 +84,7 @@ module Entropy : sig
       See {{:http://www.ieee-security.org/TC/SP2014/papers/Not-So-RandomNumbersinVirtualizedLinuxandtheWhirlwindRNG.pdf}}
       for further details. *)
 
-  val cpu_rng_bootstrap : int -> Cstruct.t
+  val cpu_rng_bootstrap : (int -> Cstruct.t, [`Not_supported]) Result.t
   (** [cpu_rng_bootstrap id] returns 8 bytes of random data using the CPU
       RNG (rdseed or rdrand). On 32bit platforms, only 4 bytes are filled.
       The [id] is used as prefix.
@@ -112,7 +112,7 @@ module Entropy : sig
   (** [feed_pools g source f] feeds all pools of [g] using [source] by executing
       [f] for each pool. *)
 
-  val cpu_rng : g option -> unit -> unit
+  val cpu_rng : (g option -> unit -> unit, [`Not_supported]) Result.t
   (** [cpu_rng g] uses the CPU RNG (rdrand or rdseed) to feed all pools
       of [g]. It uses {!feed_pools} internally. If neither rdrand nor rdseed
       are available, [fun () -> ()] is returned. *)

--- a/tests/test_entropy.ml
+++ b/tests/test_entropy.ml
@@ -2,20 +2,23 @@
 let data = ref Cstruct.empty
 
 let cpu_bootstrap_check () =
-  match Mirage_crypto_rng.Entropy.cpu_rng_bootstrap 1 with
-  | exception Failure _ -> print_endline "no CPU RNG available"
-  | data' ->
-    data := data';
-    for i = 0 to 10 do
-      try
-        let data' = Mirage_crypto_rng.Entropy.cpu_rng_bootstrap 1 in
-        if Cstruct.equal !data data' then begin
-          Cstruct.hexdump data';
-          failwith ("same data from CPU bootstrap at " ^ string_of_int i);
-        end;
-        data := data'
-      with Failure _ -> print_endline ("CPU RNG failed at " ^ string_of_int i)
-    done
+  match Mirage_crypto_rng.Entropy.cpu_rng_bootstrap with
+  | Error `Not_supported -> print_endline "no CPU RNG available"
+  | Ok cpu_rng_bootstrap ->
+    match cpu_rng_bootstrap 1 with
+    | exception Failure _ -> print_endline "bad CPU RNG"
+    | data' ->
+      data := data';
+      for i = 0 to 10 do
+        try
+          let data' = cpu_rng_bootstrap 1 in
+          if Cstruct.equal !data data' then begin
+            Cstruct.hexdump data';
+            failwith ("same data from CPU bootstrap at " ^ string_of_int i);
+          end;
+          data := data'
+        with Failure _ -> print_endline ("CPU RNG failed at " ^ string_of_int i)
+      done
 
 let whirlwind_bootstrap_check () =
   for i = 0 to 10 do


### PR DESCRIPTION
To avoid scheduling timers that do no work, require client code to match on the presence of `cpu_rng` support before attempting to use it.

It appears that `cpu_rng_bootstrap` was kindof already doing this, but with an exception. In this cases, this PR just makes what's going on a little more explicit.