### PR TITLE
mirage-crypto-rng: revise Entropy.cpu_rng to delay entropy feeding.

### DIFF
--- a/rng/async/mirage_crypto_rng_async.ml
+++ b/rng/async/mirage_crypto_rng_async.ml
@@ -17,7 +17,7 @@ let periodically_collect_cpu_entropy time_source span =
   Synchronous_time_source.run_at_intervals
     time_source
     span
-    (fun () -> Entropy.cpu_rng None)
+    (Entropy.cpu_rng None)
 
 let periodically_collect_getrandom_entropy time_source span =
   let source = Entropy.register_source "getrandom" in

--- a/rng/lwt/mirage_crypto_rng_lwt.ml
+++ b/rng/lwt/mirage_crypto_rng_lwt.ml
@@ -26,8 +26,7 @@ let getrandom_task delta source =
   periodic task delta
 
 let rdrand_task delta =
-  let task () = Entropy.cpu_rng None in
-  periodic task delta
+  periodic (Entropy.cpu_rng None) delta
 
 let running = ref false
 

--- a/rng/mirage/mirage_crypto_rng_mirage.ml
+++ b/rng/mirage/mirage_crypto_rng_mirage.ml
@@ -34,9 +34,10 @@ module Log = (val Logs.src_log src : Logs.LOG)
 module Make (T : Mirage_time.S) (M : Mirage_clock.MCLOCK) = struct
   let rdrand_task g delta =
     let open Lwt.Infix in
+    let rdrand = Entropy.cpu_rng g in
     Lwt.async (fun () ->
         let rec one () =
-          Entropy.cpu_rng g;
+          rdrand ();
           T.sleep_ns delta >>=
           one
         in

--- a/rng/mirage_crypto_rng.mli
+++ b/rng/mirage_crypto_rng.mli
@@ -112,9 +112,10 @@ module Entropy : sig
   (** [feed_pools g source f] feeds all pools of [g] using [source] by executing
       [f] for each pool. *)
 
-  val cpu_rng : g option -> unit
+  val cpu_rng : g option -> unit -> unit
   (** [cpu_rng g] uses the CPU RNG (rdrand or rdseed) to feed all pools
-      of [g]. *)
+      of [g]. It uses {!feed_pools} internally. If neither rdrand nor rdseed
+      are available, [fun () -> ()] is returned. *)
 
   (**/**)
   val id : source -> int

--- a/tests/dune
+++ b/tests/dune
@@ -35,7 +35,7 @@
  (modules test_entropy_collection)
  (package mirage-crypto-rng-mirage)
  (libraries mirage-crypto-rng-mirage mirage-unix mirage-time-unix
-   mirage-clock-unix))
+   mirage-clock-unix duration))
 
 (test
  (name test_entropy_collection_async)

--- a/tests/test_entropy_collection.ml
+++ b/tests/test_entropy_collection.ml
@@ -35,4 +35,4 @@ let with_entropy act =
   act ()
 
 let () =
-  OS.(Main.run (with_entropy (fun () -> Time.sleep_ns 1_000L)))
+  OS.(Main.run (with_entropy (fun () -> Time.sleep_ns (Duration.of_sec 3))))


### PR DESCRIPTION
This fixes #94, since register_source is called only once for the rdrand task.