### PR TITLE
bswap32/64: avoid __builtin_bswap since this is optimized by the C compiler to an SSSE3 instruction

### DIFF
--- a/config/cfg.ml
+++ b/config/cfg.ml
@@ -1,6 +1,6 @@
 let std_flags = ["--std=c99"; "-Wall"; "-Wextra"; "-Wpedantic"; "-O3"]
 
-let _ =
+let () =
   let c = Configurator.V1.create "mirage-crypto" in
   let arch =
     let defines =
@@ -24,5 +24,7 @@ let _ =
     | `x86_64 | `x86 -> [ "-DENTROPY"; "-mrdrnd"; "-mrdseed" ]
     | _ -> []
   in
-  let flags = std_flags @ ent_flags @ accelerate_flags in
+  let flags = std_flags @ ent_flags in
+  let opt_flags = flags @ accelerate_flags in
+  Configurator.V1.Flags.write_sexp "cflags_optimized.sexp" opt_flags;
   Configurator.V1.Flags.write_sexp "cflags.sexp" flags

--- a/freestanding/Makefile
+++ b/freestanding/Makefile
@@ -11,15 +11,23 @@ libmirage_crypto_freestanding_stubs.a:
 else
 CC ?= cc
 FREESTANDING_CFLAGS := $(shell PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) pkg-config --cflags ocaml-freestanding)
+MIRAGE_CRYPTO_OPT_CFLAGS := $(shell sed 's/^(\(.*\))$$/\1/' ../src/cflags_optimized.sexp | tr -d '"')
+CFLAGS := -I../src/native $(MIRAGE_CRYPTO_OPT_CFLAGS) $(FREESTANDING_CFLAGS)
+
 MIRAGE_CRYPTO_CFLAGS := $(shell sed 's/^(\(.*\))$$/\1/' ../src/cflags.sexp | tr -d '"')
-CFLAGS := -I../src/native $(MIRAGE_CRYPTO_CFLAGS) $(FREESTANDING_CFLAGS)
+UNOPT_CFLAGS := -I../src/native $(MIRAGE_CRYPTO_CFLAGS) $(FREESTANDING_CFLAGS)
+
+chacha_generic.o: chacha_generic.c
+	$(CC) $(UNOPT_CFLAGS) -c -o chacha_generic.o chacha_generic.c
+
+UNOPT_OBJS=chacha_generic.o
 
 OBJS=detect_cpu_features.o misc.o misc_sse.o hash_stubs.o md5.o sha1.o \
   sha256.o sha512.o aes_generic.o aes_aesni.o des_generic.o chacha.o \
   poly1305-donna.o ghash_pclmul.o ghash_generic.o ghash_ctmul.o \
   entropy_cpu_stubs.o
 
-libmirage_crypto_freestanding_stubs.a: $(OBJS)
+libmirage_crypto_freestanding_stubs.a: $(OBJS) $(UNOPT_OBJS)
 	$(AR) r $@ $^
 endif
 

--- a/freestanding/dune
+++ b/freestanding/dune
@@ -1,10 +1,11 @@
 (copy_files# ../src/native/*.c)
 
 (rule
- (deps ../src/cflags.sexp Makefile detect_cpu_features.c misc.c misc_sse.c
-   md5.c sha1.c sha256.c sha512.c hash_stubs.c aes_generic.c aes_aesni.c
-   ghash_generic.c ghash_pclmul.c ghash_ctmul.c des_generic.c chacha.c
-   poly1305-donna.c entropy_cpu_stubs.c)
+ (deps ../src/cflags.sexp ../src/cflags_optimized.sexp Makefile
+   detect_cpu_features.c misc.c misc_sse.c md5.c sha1.c sha256.c sha512.c
+   hash_stubs.c aes_generic.c aes_aesni.c ghash_generic.c ghash_pclmul.c
+   ghash_ctmul.c des_generic.c chacha.c chacha_generic.c poly1305-donna.c
+   entropy_cpu_stubs.c)
  (targets libmirage_crypto_freestanding_stubs.a)
  (action
   (no-infer

--- a/src/dune
+++ b/src/dune
@@ -11,6 +11,12 @@
     chacha poly1305-donna entropy_cpu_stubs)
   (flags
    (:standard)
+   (:include cflags_optimized.sexp)))
+ (foreign_stubs
+  (language c)
+  (names chacha_generic)
+  (flags
+   (:standard)
    (:include cflags.sexp))))
 
 (env
@@ -20,6 +26,6 @@
 (include_subdirs unqualified)
 
 (rule
- (targets cflags.sexp)
+ (targets cflags.sexp cflags_optimized.sexp)
  (action
   (run ../config/cfg.exe)))

--- a/src/native/bitfn.h
+++ b/src/native/bitfn.h
@@ -26,8 +26,58 @@
 #define BITFN_H
 #include <stdint.h>
 
-#define bitfn_swap32(x) __builtin_bswap32(x)
-#define bitfn_swap64(x) __builtin_bswap64(x)
+# if (defined(__i386__))
+#  define ARCH_HAS_SWAP32
+static inline uint32_t bitfn_swap32(uint32_t a)
+{
+	__asm__ ("bswap %0" : "=r" (a) : "0" (a));
+	return a;
+}
+/**********************************************************/
+# elif (defined(__arm__))
+#  define ARCH_HAS_SWAP32
+static inline uint32_t bitfn_swap32(uint32_t a)
+{
+	uint32_t tmp = a;
+	__asm__ volatile ("eor %1, %0, %0, ror #16\n"
+	                  "bic %1, %1, #0xff0000\n"
+	                  "mov %0, %0, ror #8\n"
+	                  "eor %0, %0, %1, lsr #8\n"
+	                  : "=r" (a), "=r" (tmp) : "0" (a), "1" (tmp));
+	return a;
+}
+/**********************************************************/
+# elif defined(__x86_64__)
+#  define ARCH_HAS_SWAP32
+#  define ARCH_HAS_SWAP64
+static inline uint32_t bitfn_swap32(uint32_t a)
+{
+	__asm__ ("bswap %0" : "=r" (a) : "0" (a));
+	return a;
+}
+
+static inline uint64_t bitfn_swap64(uint64_t a)
+{
+	__asm__ ("bswap %0" : "=r" (a) : "0" (a));
+	return a;
+}
+
+# endif
+
+#ifndef ARCH_HAS_SWAP32
+static inline uint32_t bitfn_swap32(uint32_t a)
+{
+	return (a << 24) | ((a & 0xff00) << 8) | ((a >> 8) & 0xff00) | (a >> 24);
+}
+#endif
+
+#ifndef ARCH_HAS_SWAP64
+static inline uint64_t bitfn_swap64(uint64_t a)
+{
+	return ((uint64_t) bitfn_swap32((uint32_t) (a >> 32))) |
+	       (((uint64_t) bitfn_swap32((uint32_t) a)) << 32);
+}
+#endif
 
 static inline uint32_t rol32(uint32_t word, uint32_t shift)
 {


### PR DESCRIPTION
(with -O3 -mssse3) to the SSSE3 PSHUFB instruction (at compile time), which is
unavailable on CPUs without SSSE3 (such as AMD Phenom II X4).

Instead, use bswap inline assembly - this is available on CPUs and not optimized
to an SSSE3 insruction. The peformance difference (with bench/speed.exe sha256)
is negligible. This should bring us back to "compile on any CPU, run anywhere"
(optimized code is used if at runtime the respective CPU features (SSSE3,
PCLMULQ, AESNI) are present - the optimized code is always generated (on X86)).

This fixes #93.