### PR TITLE
mirage-crypto-ec.Dsa raise Message_too_long in sign, verify checks di…

### DIFF
--- a/ec/mirage_crypto_ec.mli
+++ b/ec/mirage_crypto_ec.mli
@@ -20,6 +20,9 @@ type error =
 val pp_error : Format.formatter -> error -> unit
 (** Pretty printer for errors *)
 
+exception Message_too_long
+(** Raised if the provided message is too long for the curve. *)
+
 (** Diffie-Hellman key exchange. *)
 module type Dh = sig
 
@@ -102,14 +105,17 @@ module type Dsa = sig
 
   val sign : key:priv -> ?k:Cstruct.t -> Cstruct.t -> Cstruct.t * Cstruct.t
   (** [sign ~key ~k digest] signs the message [digest] using the private
-      [key]. Only the leftmost bits within the curve order are considered.
-      If [k] is not provided, it is computed using the deterministic
-      construction from RFC 6979. The result is a pair of [r] and [s]. *)
+      [key]. If [k] is not provided, it is computed using the deterministic
+      construction from RFC 6979. The result is a pair of [r] and [s].
+
+      @raise Invalid_argument if [k] is not suitable or not in range.
+      @raise Message_too_long if [msg] is too long for the curve. *)
 
   val verify : key:pub -> Cstruct.t * Cstruct.t -> Cstruct.t -> bool
   (** [verify ~key (r, s) digest] verifies the signature [r, s] on the message
       [digest] with the public [key]. The return value is [true] if verification
-      was successful, [false] otherwise. *)
+      was successful, [false] otherwise. If the message has more bits than the
+      group order, the result is false. *)
 
   (** [K_gen] can be instantiated over a hashing module to obtain an RFC6979
       compliant [k]-generator for that hash. *)

--- a/tests/test_ec.ml
+++ b/tests/test_ec.ml
@@ -289,7 +289,9 @@ let ecdsa_rfc6979_p224 =
     | Error _ -> Alcotest.fail "bad public key"
   in
   let case hash ~message ~k ~r ~s () =
-    let msg = Mirage_crypto.Hash.digest hash (Cstruct.of_string message)
+    let msg =
+      let h = Mirage_crypto.Hash.digest hash (Cstruct.of_string message) in
+      Cstruct.sub h 0 (min (Cstruct.len h) 28)
     and k = Cstruct.of_hex k
     in
     let k' =
@@ -383,7 +385,9 @@ let ecdsa_rfc6979_p256 =
     | Error _ -> Alcotest.fail "bad public key"
   in
   let case hash ~message ~k ~r ~s () =
-    let msg = Mirage_crypto.Hash.digest hash (Cstruct.of_string message)
+    let msg =
+      let h = Mirage_crypto.Hash.digest hash (Cstruct.of_string message) in
+      Cstruct.sub h 0 (min (Cstruct.len h) 32)
     and k = Cstruct.of_hex k
     in
     let k' =
@@ -466,7 +470,9 @@ let ecdsa_rfc6979_p384 =
     | Error _ -> Alcotest.fail "bad public key"
   in
   let case hash ~message ~k ~r ~s () =
-    let msg = Mirage_crypto.Hash.digest hash (Cstruct.of_string message)
+    let msg =
+      let h = Mirage_crypto.Hash.digest hash (Cstruct.of_string message) in
+      Cstruct.sub h 0 (min (Cstruct.len h) 48)
     and k = Cstruct.of_hex k
     in
     let k' =

--- a/tests/test_ec_wycheproof.ml
+++ b/tests/test_ec_wycheproof.ml
@@ -158,8 +158,11 @@ let parse_sig size cs =
 
 let make_ecdsa_test curve key hash (tst : ecdsa_test) =
   let name = Printf.sprintf "%d - %s" tst.tcId tst.comment in
-  let msg = Mirage_crypto.Hash.digest hash (Cstruct.of_string tst.msg) in
   let size = len curve in
+  let msg =
+    let h = Mirage_crypto.Hash.digest hash (Cstruct.of_string tst.msg) in
+    Cstruct.sub h 0 (min size (Cstruct.len h))
+  in
   let verified (r,s) =
     match curve with
     | "secp224r1" ->


### PR DESCRIPTION
…gest length

Previously, only the x leftmost bits were used with x being the bit size of the
group order. This could lead to two inputs X and Y with the same signature,
especially bad for verify.