### PR TITLE
Fix x25519 and ed25519 if Cstruct with off <> 0 is given as input

### DIFF
--- a/ec/mirage_crypto_ec.ml
+++ b/ec/mirage_crypto_ec.ml
@@ -783,13 +783,14 @@ end
 
 module X25519 = struct
   (* RFC 7748 *)
-  external x25519_scalar_mult_generic : Cstruct.buffer -> Cstruct.buffer -> Cstruct.buffer -> unit = "mc_x25519_scalar_mult_generic" [@@noalloc]
+  external x25519_scalar_mult_generic : Cstruct.buffer -> Cstruct.buffer -> int -> Cstruct.buffer -> int -> unit = "mc_x25519_scalar_mult_generic" [@@noalloc]
 
   let key_len = 32
 
   let scalar_mult in_ base =
     let out = Cstruct.create key_len in
-    x25519_scalar_mult_generic out.Cstruct.buffer in_.Cstruct.buffer base.Cstruct.buffer;
+    x25519_scalar_mult_generic out.Cstruct.buffer
+      in_.Cstruct.buffer in_.Cstruct.off base.Cstruct.buffer base.Cstruct.off;
     out
 
   type secret = Cstruct.t
@@ -822,7 +823,7 @@ module Ed25519 = struct
   external scalar_mult_base_to_bytes : Cstruct.buffer -> Cstruct.buffer -> unit = "mc_25519_scalar_mult_base" [@@noalloc]
   external reduce_l : Cstruct.buffer -> unit = "mc_25519_reduce_l" [@@noalloc]
   external muladd : Cstruct.buffer -> Cstruct.buffer -> Cstruct.buffer -> Cstruct.buffer -> unit = "mc_25519_muladd" [@@noalloc]
-  external double_scalar_mult : Cstruct.buffer -> Cstruct.buffer -> Cstruct.buffer -> Cstruct.buffer -> bool = "mc_25519_double_scalar_mult" [@@noalloc]
+  external double_scalar_mult : Cstruct.buffer -> Cstruct.buffer -> Cstruct.buffer -> Cstruct.buffer -> int -> bool = "mc_25519_double_scalar_mult" [@@noalloc]
   external pub_ok : Cstruct.buffer -> bool = "mc_25519_pub_ok" [@@noalloc]
 
   type pub = Cstruct.t
@@ -902,7 +903,7 @@ module Ed25519 = struct
         let r' = Cstruct.create key_len in
         let success =
           double_scalar_mult r'.Cstruct.buffer k.Cstruct.buffer
-            key.Cstruct.buffer s.Cstruct.buffer
+            key.Cstruct.buffer s.Cstruct.buffer s.Cstruct.off
         in
         success && Cstruct.equal r r'
       end else

--- a/ec/native/curve25519_stubs.c
+++ b/ec/native/curve25519_stubs.c
@@ -1804,10 +1804,10 @@ static void sc_muladd(uint8_t *s, const uint8_t *a, const uint8_t *b,
 
 #include <caml/memory.h>
 
-CAMLprim value mc_x25519_scalar_mult_generic(value out, value scalar, value point)
+CAMLprim value mc_x25519_scalar_mult_generic(value out, value scalar, value soff, value point, value poff)
 {
-  CAMLparam3(out, scalar, point);
-  x25519_scalar_mult_generic(Caml_ba_data_val(out), Caml_ba_data_val(scalar), Caml_ba_data_val(point));
+  CAMLparam5(out, scalar, soff, point, poff);
+  x25519_scalar_mult_generic(Caml_ba_data_val(out), _ba_uint8_off(scalar, soff), _ba_uint8_off(point, poff));
   CAMLreturn(Val_unit);
 }
 
@@ -1835,9 +1835,9 @@ CAMLprim value mc_25519_muladd(value out, value a, value b, value c)
   CAMLreturn(Val_unit);
 }
 
-CAMLprim value mc_25519_double_scalar_mult(value out, value k, value key, value c)
+CAMLprim value mc_25519_double_scalar_mult(value out, value k, value key, value c, value coff)
 {
-  CAMLparam4(out, k, key, c);
+  CAMLparam5(out, k, key, c, coff);
   ge_p2 R;
   ge_p3 B;
   fe_loose t;
@@ -1847,8 +1847,7 @@ CAMLprim value mc_25519_double_scalar_mult(value out, value k, value key, value 
   fe_carry(&B.X, &t);
   fe_neg(&t, &B.T);
   fe_carry(&B.T, &t);
-  ge_double_scalarmult_vartime(&R, Caml_ba_data_val(k), &B,
-                               ((uint8_t*)Caml_ba_data_val(c) + 32));
+  ge_double_scalarmult_vartime(&R, Caml_ba_data_val(k), &B, _ba_uint8_off(c, coff));
   x25519_ge_tobytes(Caml_ba_data_val(out), &R);
   CAMLreturn(Val_bool(success));
 }


### PR DESCRIPTION
Looks like I'm always making the same mistakes (and should really find (or develop) tooling which is more strict when passing pointers from OCaml to C): when passing a Cstruct.t (well, the underlying buffer), take care to add the "off" to the pointer. I reviewed the Mirage_crypto_ec module (with the assumption that Cstruct.create will always create something with off = 0) and couldn't find more cases where the off needs to be added (the tradeoff is clearly "number of arguments passed from OCaml to C").

Anyways, this PR contains some fixes, and when I reviewed the NIST curves I spotted some easy small pieces where to avoid allocations.