### PR TITLE
mirage-crypto-rng: on arm32, only read the virtual count if we're in kernel mode

### DIFF
--- a/mirage-crypto.opam
+++ b/mirage-crypto.opam
@@ -27,7 +27,7 @@ depopts: [
 ]
 conflicts: [
   "mirage-xen" {< "6.0.0"}
-  "ocaml-freestanding" {< "0.4.1"}
+  "ocaml-freestanding" {< "0.6.0"}
 ]
 description: """
 Mirage-crypto provides symmetric ciphers (DES, AES, RC4, ChaCha20/Poly1305), and


### PR DESCRIPTION
As reported and investigated by @adams-1979 in #113, reading the virtual tick
count on arm32 is only accessible in kernel mode.