### PR TITLE
Fix C stubs dependency specification in mirage-crypto-ec

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+## unreleased
+
+- mirage-crypto-ec: dune C stubs compilation rules: explicitely declare the 
+  include directory instead of listing it as a flag, so that the dependency
+  is correctly tracked (#122 by @TheLortex)
+
 ## v0.10.1 (2021-04-25)
 
 - mirage-crypto-ec: make inversion run in constant time (#121 by @dfaranha)

--- a/ec/dune
+++ b/ec/dune
@@ -6,8 +6,9 @@
   (language c)
   (names p224_stubs np224_stubs p256_stubs np256_stubs p384_stubs np384_stubs
     p521_stubs np521_stubs curve25519_stubs)
+  (include_dirs ../src/native)
   (flags
-   (:standard -I../src/native -DNDEBUG)
+   (:standard -DNDEBUG)
    (:include cflags_optimized.sexp))))
 
 (env


### PR DESCRIPTION
When using `mirage-crypto-ec` with Mirage 4, I've encountered build failures as `mirage_crypto.h` couldn't be found when building `mirage-crypto-ec`'s stubs. Indeed `dune` does not deduce from the `-I../src/native` flag that it has to track `../src/native` as a dependency folder. 

Instead the `include_dirs` option should be used: that's what this PR is about. 

In the opam world this hasn't been a problem because the dune file in `ec-freestanding` correctly specifies the dependency. 

For more information on the dune options for C compilation: https://dune.readthedocs.io/en/stable/concepts.html#foreign-stubs