### PR TITLE
Cross compile to Android ARMv7a

### DIFF
--- a/.github/workflows/esy.yml
+++ b/.github/workflows/esy.yml
@@ -11,7 +11,6 @@ jobs:
       matrix:
         system: [ubuntu, macos]
         target: [android.arm64, linux.musl.arm64, macos.arm64]
-        ocaml-version: ["~4.10.2000"]
         exclude:
           - system: ubuntu
             target: macos.arm64
@@ -29,7 +28,6 @@ jobs:
           echo '{
             "name": "cross-compile",
             "dependencies": {
-              "ocaml": "${{ matrix.ocaml-version }}",
               "@opam/mirage-crypto": "*",
               "@opam/mirage-crypto-ec": "*",
               "@opam/mirage-crypto-pk": "*",


### PR DESCRIPTION
This should fix the cross-compile CI which was broken because of the bump in OCaml version on reason-mobile to 4.12.

And it also adds android.armv7a as a target on the CI, I'm not sure if mirage-crypto currently supports 32bits but it's a good thing to have a CI to a weird Linux running armv7