### PR TITLE
Initial RISC-V support

### DIFF
--- a/src/native/entropy_cpu_stubs.c
+++ b/src/native/entropy_cpu_stubs.c
@@ -99,6 +99,15 @@ static inline uint64_t read_cycle_counter(void)
 }
 #endif
 
+#if defined (__riscv) && (64 == __riscv_xlen)
+static inline uint64_t rdcycle64(void)
+{
+  uint64_t rval;
+  __asm__ __volatile__ ("rdcycle %0" : "=r" (rval));
+  return rval;
+}
+#endif
+
 CAMLprim value mc_cycle_counter (value __unused(unit)) {
 #if defined (__i386__) || defined (__x86_64__)
   return Val_long (__rdtsc ());
@@ -106,6 +115,8 @@ CAMLprim value mc_cycle_counter (value __unused(unit)) {
   return Val_long (read_virtual_count ());
 #elif defined(__powerpc64__)
   return Val_long (read_cycle_counter ());
+#elif defined(__riscv) && (64 == __riscv_xlen)
+  return Val_long (rdcycle64 ());
 #else
 #error ("No known cycle-counting instruction.")
 #endif

--- a/src/native/mirage_crypto.h
+++ b/src/native/mirage_crypto.h
@@ -47,9 +47,9 @@ extern struct _mc_cpu_features mc_detected_cpu_features;
 
 #endif /* __mc_ACCELERATE__ */
 
-#if defined (__x86_64__) || defined (__aarch64__) || defined (__powerpc64__)
+#if defined (__x86_64__) || defined (__aarch64__) || defined (__powerpc64__) || (64 == __riscv_xlen)
 #define ARCH_64BIT
-#elif defined (__i386__) || defined (__arm__)
+#elif defined (__i386__) || defined (__arm__) || (32 == __riscv_xlen)
 #define ARCH_32BIT
 #else
 #error "unsupported platform"


### PR DESCRIPTION
Tested on Hifive Unmatched, needed to define the preprocess macro that defines this as ARCH_64BIT and implement mc_cycle_counter for RV64. `dune runtest` passes.

This is the bare minimum to get it working, I haven't (yet) implemented any accelerated instructions (there should be at least an AES extension supported by this CPU).

I didn't implement RV32 support: that needs reading both `rdcycle` / `rdcycleh` and dealing with overflow, I do not have any RV32 hardware to test on, and I think that most desktop/server-class CPUs will be 64-bit, 32-bit RISC-V is mostly for MCUs.

Also done some tests in utop to confirm that cycles gives reasonable looking answers:
```
# cd rng
# dune utop

external cycles : unit -> int = "mc_cycle_counter";;
cycles () - cycles ();;
- : int = 255
cycles () - cycles ();;
- : int = 308
cycles(); Unix.sleep 1; cycles();
- : int = 7337642441505
cycles(); Unix.sleep 1; cycles();
- : int = 8050741936328
```

Test hardware information:
```
root@unmatched:~/ocaml# lscpu
Architecture:        riscv64
Byte Order:          Little Endian
CPU(s):              4
On-line CPU(s) list: 0-3
Thread(s) per core:  4
Core(s) per socket:  1
Socket(s):           1
L1d cache:           32 KiB
L1i cache:           32 KiB
L2 cache:            2 MiB
root@unmatched:~/ocaml# cat /proc/cpuinfo 
processor       : 0
hart            : 3
isa             : rv64imafdc
mmu             : sv39
uarch           : sifive,u74-mc

processor       : 1
hart            : 1
isa             : rv64imafdc
mmu             : sv39
uarch           : sifive,u74-mc

processor       : 2
hart            : 2
isa             : rv64imafdc
mmu             : sv39
uarch           : sifive,u74-mc

processor       : 3
hart            : 4

root@unmatched:~/ocaml# cat /etc/os-release 
ID=nodistro
NAME="FreedomUSDK"
VERSION="2021.05.00 (2021May)"
VERSION_ID=2021.05.00
PRETTY_NAME="FreedomUSDK 2021.05.00 (2021May)"
isa             : rv64imafdc
mmu             : sv39
uarch           : sifive,u74-mc

root@unmatched:~/mirage-crypto# gcc -v
Using built-in specs.
COLLECT_GCC=gcc
COLLECT_LTO_WRAPPER=/usr/libexec/gcc/riscv64-oe-linux/11.1.0/lto-wrapper
Target: riscv64-oe-linux
Configured with: ../../../../../../work-shared/gcc-11.1.0-r0/gcc-11.1.0/configure --build=x86_64-linux --host=riscv64-oe-linux --target=riscv64-oe-linux --prefix=/usr --exec_prefix=/usr --bindir=/usr/bin --sbindir=/usr/sbin --libexecdir=/usr/libexec --datadir=/usr/share --sysconfdir=/etc --sharedstatedir=/com --localstatedir=/var --libdir=/usr/lib --includedir=/usr/include --oldincludedir=/usr/include --infodir=/usr/share/info --mandir=/usr/share/man --disable-silent-rules --disable-dependency-tracking --with-libtool-sysroot=/ --with-gnu-ld --enable-shared --enable-languages=c,c++,fortran --enable-threads=posix --enable-multilib --enable-default-pie --enable-c99 --enable-long-long --enable-symvers=gnu --enable-libstdcxx-pch --program-prefix=riscv64-oe-linux- --without-local-prefix --disable-install-libiberty --disable-libssp --enable-libitm --enable-lto --disable-bootstrap --with-system-zlib --with-linker-hash-style=gnu --enable-linker-build-id --with-ppl=no --with-cloog=no --enable-checking=release --enable-cheaders=c_global --without-isl --with-build-sysroot=/ --enable-nls --with-glibc-version=2.28 --enable-initfini-array --enable-__cxa_atexit
Thread model: posix
Supported LTO compression algorithms: zlib
gcc version 11.1.0 (GCC) 
```

(Note: for `utop` I had to `bitbake libev` and then install the resulting .ipk from the freedom-u-sdk, but one could also use an Ubuntu image where it is prebuilt)

`dune runtest` output: https://gist.github.com/edwintorok/2876a89dda55e3d8728e77c493804277
