### PR TITLE
Add s390x enablement to mirage-crypto

### DIFF
--- a/src/native/entropy_cpu_stubs.c
+++ b/src/native/entropy_cpu_stubs.c
@@ -108,6 +108,16 @@ static inline uint64_t rdcycle64(void)
 }
 #endif
 
+#if defined (__s390x__)
+static inline uint64_t getticks(void)
+{
+  uint64_t rval;
+  __asm__ __volatile__ ("stck %0" : "=Q" (rval) : : "cc");
+  return rval;
+}
+#endif
+
+
 CAMLprim value mc_cycle_counter (value __unused(unit)) {
 #if defined (__i386__) || defined (__x86_64__)
   return Val_long (__rdtsc ());
@@ -117,6 +127,8 @@ CAMLprim value mc_cycle_counter (value __unused(unit)) {
   return Val_long (read_cycle_counter ());
 #elif defined(__riscv) && (64 == __riscv_xlen)
   return Val_long (rdcycle64 ());
+#elif defined (__s390x__)
+  return Val_long (getticks ());
 #else
 #error ("No known cycle-counting instruction.")
 #endif

--- a/src/native/mirage_crypto.h
+++ b/src/native/mirage_crypto.h
@@ -47,7 +47,7 @@ extern struct _mc_cpu_features mc_detected_cpu_features;
 
 #endif /* __mc_ACCELERATE__ */
 
-#if defined (__x86_64__) || defined (__aarch64__) || defined (__powerpc64__) || (64 == __riscv_xlen)
+#if defined (__x86_64__) || defined (__aarch64__) || defined (__powerpc64__) || (64 == __riscv_xlen) || defined (__s390x__)
 #define ARCH_64BIT
 #elif defined (__i386__) || defined (__arm__) || (32 == __riscv_xlen)
 #define ARCH_32BIT


### PR DESCRIPTION
The two commits correct the compile failures of mirage-crypto on the IBMz s390x architecture.

Note that the STCK instruction used in the cycle count implementation guarantees a globally unique result, which is expensive. If that is not needed, STCKF instruction is less expensive.

Also s390x has the PRNO instruction to provide a pseudo-random number, if that would be useful in the other prng functions of the cpu entropy stubs file.