### PR TITLE
multicore requires c11 (using the _Atomic keyword in typedefs)

### DIFF
--- a/config/cfg.ml
+++ b/config/cfg.ml
@@ -1,4 +1,4 @@
-let std_flags = ["--std=c99"; "-Wall"; "-Wextra"; "-Wpedantic"; "-O3"]
+let std_flags = ["--std=c11"; "-Wall"; "-Wextra"; "-Wpedantic"; "-O3"]
 
 let () =
   let c = Configurator.V1.create "mirage-crypto" in


### PR DESCRIPTION
see https://github.com/ocaml-multicore/ocaml-multicore/issues/574

please confirm that this will be what OCaml-multicore will need and use.

//cc @Engil @kayceesrk @avsm @Sudha247