### PR TITLE
Set license to ISC in mirage-crypto-ec.opam

### DIFF
--- a/mirage-crypto-ec.opam
+++ b/mirage-crypto-ec.opam
@@ -20,7 +20,7 @@ authors: [
   "Massachusetts Institute of Technology"
   "Zoe Paraskevopoulou <zoe.paraskevopoulou@gmail.com>"
 ]
-license: "MIT"
+license: "ISC"
 homepage: "https://github.com/mirage/mirage-crypto"
 doc: "https://mirage.github.io/mirage-crypto/doc"
 bug-reports: "https://github.com/mirage/mirage-crypto/issues"


### PR DESCRIPTION
Assuming that all packages are licensed under ISC and that this is a typo.