### PR TITLE
Debian fixes

### DIFF
--- a/src/native/entropy_cpu_stubs.c
+++ b/src/native/entropy_cpu_stubs.c
@@ -135,6 +135,14 @@ static inline uint64_t getticks(void)
 }
 #endif
 
+#if defined (__mips__)
+static inline unsigned long get_count() {
+  unsigned long count;
+  __asm__ __volatile__ ("rdhwr %[rt], $2" : [rt] "=d" (count));
+  return count;
+}
+#endif
+
 
 CAMLprim value mc_cycle_counter (value __unused(unit)) {
 #if defined (__i386__) || defined (__x86_64__)
@@ -147,6 +155,8 @@ CAMLprim value mc_cycle_counter (value __unused(unit)) {
   return Val_long (rdcycle64 ());
 #elif defined (__s390x__)
   return Val_long (getticks ());
+#elif defined(__mips__)
+  return Val_long (get_count());
 #else
 #error ("No known cycle-counting instruction.")
 #endif

--- a/src/native/ghash_ctmul.c
+++ b/src/native/ghash_ctmul.c
@@ -39,7 +39,7 @@
 #include "mirage_crypto.h"
 #include <string.h>
 
-#if defined (__i386__) || defined (__arm__)
+#if defined (__i386__) || defined (__arm__) || (defined (__mips__) && _MIPS_SIM==_ABIO32)
 
 /*
  * We cannot really autodetect whether multiplications are "slow" or

--- a/src/native/mirage_crypto.h
+++ b/src/native/mirage_crypto.h
@@ -47,9 +47,9 @@ extern struct _mc_cpu_features mc_detected_cpu_features;
 
 #endif /* __mc_ACCELERATE__ */
 
-#if defined (__x86_64__) || defined (__aarch64__) || defined (__powerpc64__) || (64 == __riscv_xlen) || defined (__s390x__)
+#if defined (__x86_64__) || defined (__aarch64__) || defined (__powerpc64__) || (64 == __riscv_xlen) || defined (__s390x__) || (defined (__mips__) && _MIPS_SIM==_ABI64)
 #define ARCH_64BIT
-#elif defined (__i386__) || defined (__arm__) || (32 == __riscv_xlen)
+#elif defined (__i386__) || defined (__arm__) || (32 == __riscv_xlen) || (defined (__mips__) && _MIPS_SIM==_ABIO32)
 #define ARCH_32BIT
 #else
 #error "unsupported platform"


### PR DESCRIPTION
Here are patches, applied in Debian, to improve portability of mirage-crypto.