### PR TITLE
eio: disable building/testing eio packages in ocaml versions < 5.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,9 @@ jobs:
       - name: Use OCaml ${{ matrix.ocaml-version }}
         uses: ocaml/setup-ocaml@v2
         with:
+          opam-local-packages: |
+            *.opam
+            !mirage-crypto-rng-eio.opam
           ocaml-compiler: ${{ matrix.ocaml-version }}
 
       - name: Install dependencies

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -24,6 +24,7 @@ jobs:
           opam-local-packages: |
             *.opam
             !mirage-crypto-rng-async.opam
+            !mirage-crypto-rng-eio.opam
           ocaml-compiler: ${{ matrix.ocaml-version }}
 
       - name: Install dependencies


### PR DESCRIPTION
This PR fixes github workflow CI as it doesn't support ocaml 5.0 yet. It needs to be merged before https://github.com/mirage/mirage-crypto/pull/155.

cc @hannesm 