### PR TITLE
Ci use mirage4

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -4,8 +4,8 @@ freebsd_instance:
 freebsd_task:
   env:
     matrix:
-      - OCAML_VERSION: 4.11.1
-      - OCAML_VERSION: 4.12.0
+      - OCAML_VERSION: 4.13.1
+      - OCAML_VERSION: 4.14.0
 
   pkg_install_script: pkg install -y ocaml-opam gmp gmake pkgconf bash
 
@@ -14,7 +14,6 @@ freebsd_task:
     - opam env
 
   pin_packages_script:
-    - opam install -y solo5-bindings-hvt zarith-freestanding opam-depext
     - opam install -y --deps-only -t ./mirage-crypto.opam ./mirage-crypto-rng.opam ./mirage-crypto-rng-mirage.opam ./mirage-crypto-rng-async.opam ./mirage-crypto-ec.opam ./mirage-crypto-pk.opam
 
   test_script: opam exec -- dune runtest -p mirage-crypto,mirage-crypto-rng,mirage-crypto-rng-mirage,mirage-crypto-pk,mirage-crypto-ec,mirage-crypto-rng-async

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -26,7 +26,7 @@ freebsd_eio_task:
   ocaml_script:
     - opam init -a --bare
     - opam update
-    - opam switch create 5.0.0~alpha0 --repositories=default,alpha=git+https://github.com/kit-ty-kate/opam-alpha-repository.git
+    - opam switch create 5.0.0~beta1 --repositories=default,alpha=git+https://github.com/kit-ty-kate/opam-alpha-repository.git
     - opam env
 
   pin_packages_script:

--- a/.test-mirage.sh
+++ b/.test-mirage.sh
@@ -10,8 +10,8 @@ echo $version >> mirage-crypto-rng-mirage.opam
 echo $version >> mirage-crypto-rng.opam
 echo $version >> mirage-crypto.opam
 echo $version >> mirage-crypto-pk.opam
-(mirage configure -t unix -f mirage/config.ml && gmake depend && mirage build -f mirage/config.ml && mirage/dist/crypto-test) || exit 1
-(mirage configure -t hvt -f mirage/config.ml && gmake depend && mirage build -f mirage/config.ml) || exit 1
+(mirage configure -t unix -f mirage/config.ml && gmake depend && dune build --root . mirage/dist/ && mirage/dist/crypto-test) || exit 1
+(mirage configure -t hvt -f mirage/config.ml && gmake depend && dune build --root . mirage/dist/) || exit 1
 if [ $(uname -m) = "amd64" ] || [ $(uname -m) = "x86_64" ]; then
-    (mirage configure -t xen -f mirage/config.ml && gmake depend && mirage build -f mirage/config.ml) || exit 1
+    (mirage configure -t xen -f mirage/config.ml && gmake depend && dune build --root . mirage/dist/) || exit 1
 fi

--- a/.test-mirage.sh
+++ b/.test-mirage.sh
@@ -2,9 +2,9 @@
 
 set -ex
 
-opam install -y "mirage<4"
-(cd mirage && mirage configure -t unix && make depend && mirage build && ./crypto_test && mirage clean && cd ..) || exit 1
-(cd mirage && mirage configure -t hvt && make depend && mirage build && mirage clean && cd ..) || exit 1
+opam install --confirm-level=unsafe-yes "mirage>4"
+(cd mirage && mirage configure -t unix && gmake depend && mirage build && dist/crypto-test && cd ..) || exit 1
+(cd mirage && mirage configure -t hvt && gmake depend && mirage build && cd ..) || exit 1
 if [ $(uname -m) = "amd64" ] || [ $(uname -m) = "x86_64" ]; then
-    (cd mirage && mirage configure -t xen && make depend && mirage build && mirage clean && cd ..) || exit 1
+    (cd mirage && mirage configure -t xen && gmake depend && mirage build && cd ..) || exit 1
 fi

--- a/.test-mirage.sh
+++ b/.test-mirage.sh
@@ -3,8 +3,9 @@
 set -ex
 
 opam install --confirm-level=unsafe-yes "mirage>4"
-(cd mirage && mirage configure -t unix && gmake depend && mirage build && dist/crypto-test && cd ..) || exit 1
-(cd mirage && mirage configure -t hvt && gmake depend && mirage build && cd ..) || exit 1
+dune subst
+(mirage configure -t unix -f mirage/config.ml && gmake depend && mirage build -f mirage/config.ml && mirage/dist/crypto-test) || exit 1
+(mirage configure -t hvt -f mirage/config.ml && gmake depend && mirage build -f mirage/config.ml) || exit 1
 if [ $(uname -m) = "amd64" ] || [ $(uname -m) = "x86_64" ]; then
-    (cd mirage && mirage configure -t xen && gmake depend && mirage build && cd ..) || exit 1
+    (mirage configure -t xen -f mirage/config.ml && gmake depend && mirage build -f mirage/config.ml) || exit 1
 fi

--- a/.test-mirage.sh
+++ b/.test-mirage.sh
@@ -3,7 +3,13 @@
 set -ex
 
 opam install --confirm-level=unsafe-yes "mirage>4"
-dune subst
+# to satisfy hardcoded version constraints in mirage, we need to be < 0.11.0
+# and "dune subst" doesn't work on these PR checkouts
+version='version: "0.10.99~dev"'
+echo $version >> mirage-crypto-rng-mirage.opam
+echo $version >> mirage-crypto-rng.opam
+echo $version >> mirage-crypto.opam
+echo $version >> mirage-crypto-pk.opam
 (mirage configure -t unix -f mirage/config.ml && gmake depend && mirage build -f mirage/config.ml && mirage/dist/crypto-test) || exit 1
 (mirage configure -t hvt -f mirage/config.ml && gmake depend && mirage build -f mirage/config.ml) || exit 1
 if [ $(uname -m) = "amd64" ] || [ $(uname -m) = "x86_64" ]; then

--- a/dune-project
+++ b/dune-project
@@ -1,3 +1,3 @@
-(lang dune 2.6)
+(lang dune 2.7)
 (name mirage-crypto)
 (formatting disabled)

--- a/mirage-crypto-ec.opam
+++ b/mirage-crypto-ec.opam
@@ -26,7 +26,7 @@ doc: "https://mirage.github.io/mirage-crypto/doc"
 bug-reports: "https://github.com/mirage/mirage-crypto/issues"
 depends: [
   "conf-pkg-config" {build}
-  "dune" {>= "2.6"}
+  "dune" {>= "2.7"}
   "ocaml" {>= "4.08.0"}
   "cstruct" {>= "6.0.0"}
   "dune-configurator"

--- a/mirage-crypto-pk.opam
+++ b/mirage-crypto-pk.opam
@@ -15,7 +15,7 @@ build: [ ["dune" "subst"] {dev}
 depends: [
   "conf-gmp-powm-sec" {build}
   "ocaml" {>= "4.08.0"}
-  "dune" {>= "2.6"}
+  "dune" {>= "2.7"}
   "ounit2" {with-test}
   "randomconv" {with-test & >= "0.1.3"}
   "cstruct" {>="6.00"}

--- a/mirage-crypto-rng-async.opam
+++ b/mirage-crypto-rng-async.opam
@@ -14,7 +14,7 @@ build: [ ["dune" "subst"] {dev}
 
 depends: [
   "ocaml" {>= "4.08.0"}
-  "dune" {>= "2.6"}
+  "dune" {>= "2.7"}
   "dune-configurator" {>= "2.0.0"}
   "async" {>= "v0.14"}
   "logs"

--- a/mirage-crypto-rng-mirage.opam
+++ b/mirage-crypto-rng-mirage.opam
@@ -14,7 +14,7 @@ build: [ ["dune" "subst"] {dev}
 
 depends: [
   "ocaml" {>= "4.08.0"}
-  "dune" {>= "2.6"}
+  "dune" {>= "2.7"}
   "mirage-crypto-rng" {=version}
   "duration"
   "cstruct" {>= "4.0.0"}

--- a/mirage-crypto-rng.opam
+++ b/mirage-crypto-rng.opam
@@ -14,7 +14,7 @@ build: [ ["dune" "subst"] {dev}
 
 depends: [
   "ocaml" {>= "4.08.0"}
-  "dune" {>= "2.6"}
+  "dune" {>= "2.7"}
   "dune-configurator" {>= "2.0.0"}
   "duration"
   "cstruct" {>= "6.0.0"}

--- a/mirage-crypto.opam
+++ b/mirage-crypto.opam
@@ -15,7 +15,7 @@ build: [ ["dune" "subst"] {dev}
 depends: [
   "conf-pkg-config" {build}
   "ocaml" {>= "4.08.0"}
-  "dune" {>= "2.6"}
+  "dune" {>= "2.7"}
   "dune-configurator" {>= "2.0.0"}
   "ounit2" {with-test}
   "cstruct" {>="6.0.0"}


### PR DESCRIPTION
//cc @TheLortex applying your suggestion from https://github.com/mirage/mirage/issues/1346 -- but somehow the CI fails since now a `mirage build` attempts to cross-compile everything, and not only the unikernel.

Also, in the generated `Makefile` (at top level) the `build` target omits the `-f mirage/config.ml` -- is this intentional?