### PR TITLE
mirage-crypto-rng-eio: require ocaml 5, and dune 2.7

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -5,7 +5,7 @@ freebsd_task:
   env:
     matrix:
       - OCAML_VERSION: 4.13.1
-      - OCAML_VERSION: 4.14.0
+      - OCAML_VERSION: 4.14.1
 
   pkg_install_script: pkg install -y ocaml-opam gmp gmake pkgconf bash
 
@@ -24,9 +24,7 @@ freebsd_eio_task:
   pkg_install_script: pkg install -y ocaml-opam gmake pkgconf bash
 
   ocaml_script:
-    - opam init -a --bare
-    - opam update
-    - opam switch create 5.0.0~beta1 --repositories=default,alpha=git+https://github.com/kit-ty-kate/opam-alpha-repository.git
+    - opam init -a --comp=5.0.0
     - opam env
 
   pin_packages_script:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ocaml-version: ["4.12.0", "4.11.2", "4.10.2", "4.09.1", "4.08.1"]
+        ocaml-version: ["4.14.1", "4.13.1", "4.12.1", "4.11.2", "4.10.2", "4.09.1", "4.08.1"]
         operating-system: [macos-latest, ubuntu-latest]
 
     runs-on: ${{ matrix.operating-system }}
@@ -41,7 +41,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ocaml-version: [ocaml-variants.5.0.0+trunk]
+        ocaml-version: ["5.0.0"]
         operating-system: [macos-latest, ubuntu-latest]
 
     runs-on: ${{ matrix.operating-system }}
@@ -58,9 +58,6 @@ jobs:
             mirage-crypto-rng.opam
             mirage-crypto-rng-eio.opam
           ocaml-compiler: ${{ matrix.ocaml-version }}
-          opam-repositories: |
-            default: https://github.com/ocaml/opam-repository.git
-            alpha: https://github.com/kit-ty-kate/opam-alpha-repository.git
 
       - name: Install dependencies
         run: opam install --deps-only -t mirage-crypto mirage-crypto-rng mirage-crypto-rng-eio

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ocaml-version: ["4.12.0", "4.11.2", "4.10.2", "4.09.1", "4.08.1"]
+        ocaml-version: ["4.14.0", "4.13.1", "4.12.1", "4.11.2", "4.10.2", "4.09.1", "4.08.1"]
         operating-system: [windows-latest]
 
     runs-on: ${{ matrix.operating-system }}

--- a/mirage-crypto-ec.opam
+++ b/mirage-crypto-ec.opam
@@ -34,7 +34,7 @@ depends: [
   "mirage-crypto-rng" {=version}
   "mirage-crypto-pk" {with-test & =version}
   "hex" {with-test}
-  "alcotest" {with-test}
+  "alcotest" {with-test & >= "0.8.1"}
   "asn1-combinators" {with-test & >= "0.2.5"}
   "ppx_deriving_yojson" {with-test}
   "ppx_deriving" {with-test}

--- a/mirage-crypto-rng-eio.opam
+++ b/mirage-crypto-rng-eio.opam
@@ -13,8 +13,8 @@ build: [ ["dune" "subst"] {dev}
          ["dune" "runtest" "-p" name "-j" jobs] {with-test} ]
 
 depends: [
-  "base-domains"
-  "dune" {>= "3.0"}
+  "ocaml" {>= "5.0.0"}
+  "dune" {>= "2.7"}
   "eio" {>= "0.3"}
   "cstruct" {>= "6.0.0"}
   "logs"


### PR DESCRIPTION
CI: remove alpha hacks now that ocaml 5 is released

also setup 4.13 and 4.14 runners in github actions