### PR TITLE
mirage-crypto: improve AEAD API, provide tag_size and of_secret

### DIFF
--- a/bench/speed.ml
+++ b/bench/speed.ml
@@ -289,9 +289,9 @@ let benchmarks = [
     throughput name (fun cs -> AES.GCM.authenticate_encrypt ~key ~nonce ~adata:cs Cstruct.empty));
 
   bm "aes-128-ccm" (fun name ->
-    let key   = AES.CCM.of_secret ~maclen:16 (Mirage_crypto_rng.generate 16)
+    let key   = AES.CCM16.of_secret (Mirage_crypto_rng.generate 16)
     and nonce = Mirage_crypto_rng.generate 10 in
-    throughput name (fun cs -> AES.CCM.authenticate_encrypt ~key ~nonce cs));
+    throughput name (fun cs -> AES.CCM16.authenticate_encrypt ~key ~nonce cs));
 
   bm "aes-192-ecb" (fun name ->
     let key = AES.ECB.of_secret (Mirage_crypto_rng.generate 24) in

--- a/src/aead.ml
+++ b/src/aead.ml
@@ -2,12 +2,12 @@ module type AEAD = sig
   val tag_size : int
   type key
   val of_secret : Cstruct.t -> key
-  val authenticate_encrypt_tag : key:key -> nonce:Cstruct.t ->
-    ?adata:Cstruct.t -> Cstruct.t -> Cstruct.t * Cstruct.t
   val authenticate_encrypt : key:key -> nonce:Cstruct.t -> ?adata:Cstruct.t ->
     Cstruct.t -> Cstruct.t
-  val authenticate_decrypt_tag : key:key -> nonce:Cstruct.t -> ?adata:Cstruct.t ->
-    tag:Cstruct.t -> Cstruct.t -> Cstruct.t option
   val authenticate_decrypt : key:key -> nonce:Cstruct.t -> ?adata:Cstruct.t ->
     Cstruct.t -> Cstruct.t option
+  val authenticate_encrypt_tag : key:key -> nonce:Cstruct.t ->
+    ?adata:Cstruct.t -> Cstruct.t -> Cstruct.t * Cstruct.t
+  val authenticate_decrypt_tag : key:key -> nonce:Cstruct.t -> ?adata:Cstruct.t ->
+    tag:Cstruct.t -> Cstruct.t -> Cstruct.t option
 end

--- a/src/aead.ml
+++ b/src/aead.ml
@@ -1,5 +1,7 @@
 module type AEAD = sig
+  val tag_size : int
   type key
+  val of_secret : Cstruct.t -> key
   val authenticate_encrypt : key:key -> nonce:Cstruct.t -> ?adata:Cstruct.t ->
     Cstruct.t -> Cstruct.t
   val authenticate_decrypt : key:key -> nonce:Cstruct.t -> ?adata:Cstruct.t ->

--- a/src/aead.ml
+++ b/src/aead.ml
@@ -2,8 +2,12 @@ module type AEAD = sig
   val tag_size : int
   type key
   val of_secret : Cstruct.t -> key
+  val authenticate_encrypt_tag : key:key -> nonce:Cstruct.t ->
+    ?adata:Cstruct.t -> Cstruct.t -> Cstruct.t * Cstruct.t
   val authenticate_encrypt : key:key -> nonce:Cstruct.t -> ?adata:Cstruct.t ->
     Cstruct.t -> Cstruct.t
+  val authenticate_decrypt_tag : key:key -> nonce:Cstruct.t -> ?adata:Cstruct.t ->
+    tag:Cstruct.t -> Cstruct.t -> Cstruct.t option
   val authenticate_decrypt : key:key -> nonce:Cstruct.t -> ?adata:Cstruct.t ->
     Cstruct.t -> Cstruct.t option
 end

--- a/src/chacha20.ml
+++ b/src/chacha20.ml
@@ -88,20 +88,27 @@ let mac ~key ~adata ciphertext =
   let ctx = P.feed ctx len in
   P.get ctx
 
-let authenticate_encrypt ~key ~nonce ?(adata = Cstruct.empty) data =
+let authenticate_encrypt_tag ~key ~nonce ?(adata = Cstruct.empty) data =
   let poly1305_key = generate_poly1305_key ~key ~nonce in
   let ciphertext = crypt ~key ~nonce ~ctr:1L data in
   let mac = mac ~key:poly1305_key ~adata ciphertext in
-  Cstruct.append ciphertext mac
+  ciphertext, mac
 
-let authenticate_decrypt ~key ~nonce ?(adata = Cstruct.empty) data =
+let authenticate_encrypt ~key ~nonce ?adata data =
+  let cdata, ctag = authenticate_encrypt_tag ~key ~nonce ?adata data in
+  Cstruct.append cdata ctag
+
+let authenticate_decrypt_tag ~key ~nonce ?(adata = Cstruct.empty) ~tag data =
+  let poly1305_key = generate_poly1305_key ~key ~nonce in
+  let ctag = mac ~key:poly1305_key ~adata data in
+  let plain = crypt ~key ~nonce ~ctr:1L data in
+  if Eqaf_cstruct.equal tag ctag then Some plain else None
+
+let authenticate_decrypt ~key ~nonce ?adata data =
   if Cstruct.length data < P.mac_size then
     None
   else
     let cipher, tag = Cstruct.split data (Cstruct.length data - P.mac_size) in
-    let poly1305_key = generate_poly1305_key ~key ~nonce in
-    let ctag = mac ~key:poly1305_key ~adata cipher in
-    let plain = crypt ~key ~nonce ~ctr:1L cipher in
-    if Eqaf_cstruct.equal tag ctag then Some plain else None
+    authenticate_decrypt_tag ~key ~nonce ?adata ~tag cipher
 
 let tag_size = P.mac_size

--- a/src/chacha20.ml
+++ b/src/chacha20.ml
@@ -103,3 +103,5 @@ let authenticate_decrypt ~key ~nonce ?(adata = Cstruct.empty) data =
     let ctag = mac ~key:poly1305_key ~adata cipher in
     let plain = crypt ~key ~nonce ~ctr:1L cipher in
     if Eqaf_cstruct.equal tag ctag then Some plain else None
+
+let tag_size = P.mac_size

--- a/src/mirage_crypto.mli
+++ b/src/mirage_crypto.mli
@@ -250,8 +250,18 @@ end
 *)
 module type AEAD = sig
 
+  val tag_size : int
+  (** The size of the authentication tag. *)
+
   type key
   (** The abstract type for the key. *)
+
+  val of_secret : Cstruct.t -> key
+  (** [of_secret secret] constructs the encryption key corresponding to
+      [secret].
+
+      @raise Invalid_argument if the length of [secret] is not a valid key size.
+  *)
 
   val authenticate_encrypt : key:key -> nonce:Cstruct.t -> ?adata:Cstruct.t ->
     Cstruct.t -> Cstruct.t
@@ -430,42 +440,23 @@ module Cipher_block : sig
 
       include AEAD
 
-      val of_secret : Cstruct.t -> key
-      (** Construct the encryption key corresponding to [secret].
-
-          @raise Invalid_argument if the length of [secret] is not in
-          {{!key_sizes}[key_sizes]}. *)
-
       val key_sizes  : int array
       (** Key sizes allowed with this cipher. *)
 
       val block_size : int
       (** The size of a single block. *)
-
-       val tag_size : int
-      (** The size of the authentication tag. *)
     end
 
     (** {e Counter with CBC-MAC} mode. *)
-    module type CCM = sig
+    module type CCM16 = sig
 
       include AEAD
-
-      val of_secret : maclen:int -> Cstruct.t -> key
-      (** Construct the encryption key corresponding to [secret], that will
-          produce authentication codes with the length [maclen].
-
-          @raise Invalid_argument if the length of [secret] is not in
-          {{!key_sizes}[key_sizes]} or [maclen] is not in [mac_sizes] *)
 
       val key_sizes  : int array
       (** Key sizes allowed with this cipher. *)
 
       val block_size : int
       (** The size of a single block. *)
-
-      val mac_sizes  : int array
-      (** [MAC] lengths allowed with this cipher. *)
     end
   end
 
@@ -475,7 +466,7 @@ module Cipher_block : sig
     module CBC  : S.CBC
     module CTR  : S.CTR with type ctr = int64 * int64
     module GCM  : S.GCM
-    module CCM  : S.CCM
+    module CCM16  : S.CCM16
   end
 
   module DES : sig
@@ -493,8 +484,6 @@ end
 (** The ChaCha20 cipher proposed by D.J. Bernstein. *)
 module Chacha20 : sig
   include AEAD
-
-  val of_secret : Cstruct.t -> key
 
   val crypt : key:key -> nonce:Cstruct.t -> ?ctr:int64 -> Cstruct.t -> Cstruct.t
   (** [crypt ~key ~nonce ~ctr data] generates a ChaCha20 key stream using

--- a/src/mirage_crypto.mli
+++ b/src/mirage_crypto.mli
@@ -263,11 +263,28 @@ module type AEAD = sig
       @raise Invalid_argument if the length of [secret] is not a valid key size.
   *)
 
+  val authenticate_encrypt_tag : key:key -> nonce:Cstruct.t ->
+    ?adata:Cstruct.t -> Cstruct.t -> Cstruct.t * Cstruct.t
+  (** [authenticate_encrypt_tag ~key ~nonce ~adata msg] encrypts [msg] with [key]
+      and [nonce]. The computed authentication tag is returned separately as
+      second part of the tuple.
+
+      @raise Invalid_argument if [nonce] is not of the right size. *)
+
   val authenticate_encrypt : key:key -> nonce:Cstruct.t -> ?adata:Cstruct.t ->
     Cstruct.t -> Cstruct.t
   (** [authenticate_encrypt ~key ~nonce ~adata msg] encrypts [msg] with [key]
       and [nonce], and appends an authentication tag computed over the encrypted
       [msg], using [key], [nonce], and [adata].
+
+      @raise Invalid_argument if [nonce] is not of the right size. *)
+
+  val authenticate_decrypt_tag : key:key -> nonce:Cstruct.t ->
+    ?adata:Cstruct.t -> tag:Cstruct.t -> Cstruct.t -> Cstruct.t option
+  (** [authenticate_decrypt ~key ~nonce ~adata ~tag msg] computes the
+      authentication tag using [key], [nonce], and [adata], and decrypts the
+      encrypted data. If the authentication tags match, the decrypted data is
+      returned.
 
       @raise Invalid_argument if [nonce] is not of the right size. *)
 

--- a/src/mirage_crypto.mli
+++ b/src/mirage_crypto.mli
@@ -263,13 +263,7 @@ module type AEAD = sig
       @raise Invalid_argument if the length of [secret] is not a valid key size.
   *)
 
-  val authenticate_encrypt_tag : key:key -> nonce:Cstruct.t ->
-    ?adata:Cstruct.t -> Cstruct.t -> Cstruct.t * Cstruct.t
-  (** [authenticate_encrypt_tag ~key ~nonce ~adata msg] encrypts [msg] with [key]
-      and [nonce]. The computed authentication tag is returned separately as
-      second part of the tuple.
-
-      @raise Invalid_argument if [nonce] is not of the right size. *)
+  (** {1 Authenticated encryption and decryption with inline tag} *)
 
   val authenticate_encrypt : key:key -> nonce:Cstruct.t -> ?adata:Cstruct.t ->
     Cstruct.t -> Cstruct.t
@@ -279,21 +273,31 @@ module type AEAD = sig
 
       @raise Invalid_argument if [nonce] is not of the right size. *)
 
-  val authenticate_decrypt_tag : key:key -> nonce:Cstruct.t ->
-    ?adata:Cstruct.t -> tag:Cstruct.t -> Cstruct.t -> Cstruct.t option
-  (** [authenticate_decrypt ~key ~nonce ~adata ~tag msg] computes the
-      authentication tag using [key], [nonce], and [adata], and decrypts the
-      encrypted data. If the authentication tags match, the decrypted data is
-      returned.
-
-      @raise Invalid_argument if [nonce] is not of the right size. *)
-
   val authenticate_decrypt : key:key -> nonce:Cstruct.t -> ?adata:Cstruct.t ->
     Cstruct.t -> Cstruct.t option
   (** [authenticate_decrypt ~key ~nonce ~adata msg] splits [msg] into encrypted
       data and authentication tag, computes the authentication tag using [key],
       [nonce], and [adata], and decrypts the encrypted data. If the
       authentication tags match, the decrypted data is returned.
+
+      @raise Invalid_argument if [nonce] is not of the right size. *)
+
+  (** {1 Authenticated encryption and decryption with tag provided separately} *)
+
+  val authenticate_encrypt_tag : key:key -> nonce:Cstruct.t ->
+    ?adata:Cstruct.t -> Cstruct.t -> Cstruct.t * Cstruct.t
+  (** [authenticate_encrypt_tag ~key ~nonce ~adata msg] encrypts [msg] with [key]
+      and [nonce]. The computed authentication tag is returned separately as
+      second part of the tuple.
+
+      @raise Invalid_argument if [nonce] is not of the right size. *)
+
+  val authenticate_decrypt_tag : key:key -> nonce:Cstruct.t ->
+    ?adata:Cstruct.t -> tag:Cstruct.t -> Cstruct.t -> Cstruct.t option
+  (** [authenticate_decrypt ~key ~nonce ~adata ~tag msg] computes the
+      authentication tag using [key], [nonce], and [adata], and decrypts the
+      encrypted data. If the authentication tags match, the decrypted data is
+      returned.
 
       @raise Invalid_argument if [nonce] is not of the right size. *)
 end

--- a/tests/test_cipher.ml
+++ b/tests/test_cipher.ml
@@ -283,6 +283,7 @@ let gcm_cases =
 ]
 
 
+(*
 (* from SP800-38C_updated-July20_2007.pdf appendix C *)
 let ccm_cases =
   let open Cipher_block.AES.CCM in
@@ -320,13 +321,14 @@ let ccm_cases =
          ~c:      "e3b201a9f5b71a7a9b1ceaeccd97e70b6176aad9a4428aa5484392fbc1b09951"
          ~maclen: 8
   ]
+*)
 
 let ccm_regressions =
-  let open Cipher_block.AES.CCM in
+  let open Cipher_block.AES.CCM16 in
   let no_vs_empty_ad _ =
     (* as reported in https://github.com/mirleft/ocaml-nocrypto/issues/166 *)
     (* see RFC 3610 Section 2.1, AD of length 0 should be same as no AD *)
-    let key = of_secret ~maclen:16 (vx "000102030405060708090a0b0c0d0e0f")
+    let key = of_secret (vx "000102030405060708090a0b0c0d0e0f")
     and nonce = vx "0001020304050607"
     and plaintext = Cstruct.of_string "hello"
     in
@@ -337,7 +339,7 @@ let ccm_regressions =
     (* as reported in https://github.com/mirleft/ocaml-nocrypto/issues/167 *)
     (* valid nonce sizes for CCM are 7..13 (L can be 2..8, nonce is 15 - L)*)
     (* see RFC3610 Section 2.1 *)
-    let key = of_secret ~maclen:16 (vx "000102030405060708090a0b0c0d0e0f")
+    let key = of_secret (vx "000102030405060708090a0b0c0d0e0f")
     and nonce = Cstruct.empty
     and plaintext = Cstruct.of_string "hello"
     in
@@ -345,7 +347,7 @@ let ccm_regressions =
       (Invalid_argument "Mirage_crypto: CCM: nonce length not between 7 and 13: 0")
       (fun () -> authenticate_encrypt ~key ~nonce plaintext)
   and short_nonce_enc2 _ =
-    let key = of_secret ~maclen:16 (vx "000102030405060708090a0b0c0d0e0f")
+    let key = of_secret (vx "000102030405060708090a0b0c0d0e0f")
     and nonce = vx "00"
     and plaintext = Cstruct.of_string "hello"
     in
@@ -353,7 +355,7 @@ let ccm_regressions =
       (Invalid_argument "Mirage_crypto: CCM: nonce length not between 7 and 13: 1")
       (fun () -> authenticate_encrypt ~key ~nonce plaintext)
   and short_nonce_enc3 _ =
-    let key = of_secret ~maclen:16 (vx "000102030405060708090a0b0c0d0e0f")
+    let key = of_secret (vx "000102030405060708090a0b0c0d0e0f")
     and nonce = vx "000102030405"
     and plaintext = Cstruct.of_string "hello"
     in
@@ -361,7 +363,7 @@ let ccm_regressions =
       (Invalid_argument "Mirage_crypto: CCM: nonce length not between 7 and 13: 6")
       (fun () -> authenticate_encrypt ~key ~nonce plaintext)
   and long_nonce_enc _ =
-    let key = of_secret ~maclen:16 (vx "000102030405060708090a0b0c0d0e0f")
+    let key = of_secret (vx "000102030405060708090a0b0c0d0e0f")
     and nonce = vx "000102030405060708090a0b0c0d"
     and plaintext = Cstruct.of_string "hello"
     in
@@ -370,7 +372,7 @@ let ccm_regressions =
       (fun () -> authenticate_encrypt ~key ~nonce plaintext)
   and enc_dec_empty_message _ =
     (* as reported in https://github.com/mirleft/ocaml-nocrypto/issues/168 *)
-    let key = of_secret ~maclen:16 (vx "000102030405060708090a0b0c0d0e0f")
+    let key = of_secret (vx "000102030405060708090a0b0c0d0e0f")
     and nonce = vx "0001020304050607"
     and adata = Cstruct.of_string "hello"
     and p = Cstruct.empty
@@ -692,7 +694,7 @@ let suite = [
   "AES-CBC" >::: [ "SP 300-38A" >::: aes_cbc_cases ] ;
   "AES-CTR" >::: [ "SP 300-38A" >::: aes_ctr_cases; ] ;
   "AES-GCM" >::: gcm_cases ;
-  "AES-CCM" >::: ccm_cases ;
+  (* "AES-CCM" >::: ccm_cases ; *)
   "AES-CCM-REGRESSION" >::: ccm_regressions ;
   "AES-GCM-REGRESSION" >::: gcm_regressions ;
   "Chacha20" >::: chacha20_cases ;


### PR DESCRIPTION
this provides CCM only with mac length / tag size of 16 bytes, all other possible mac sizes are not exposed.

first commit is first half of #73 