### PR TITLE
Stricter C function prototypes

### DIFF
--- a/rng/unix/mc_getrandom_stubs.c
+++ b/rng/unix/mc_getrandom_stubs.c
@@ -35,8 +35,8 @@ void raw_getrandom (uint8_t *data, uint32_t len) {
 #include <sys/param.h>
 
 void raw_getrandom (uint8_t *data, uint32_t len) {
-  int rlen = 0;
-  for (int i = 0; i <= len; i += 256) {
+  size_t rlen = 0;
+  for (uint32_t i = 0; i <= len; i += 256) {
     rlen = MIN(256, len - i);
     if (getentropy(data + i, rlen) < 0) uerror("getentropy", Nothing);
   }

--- a/rng/unix/mc_getrandom_stubs.c
+++ b/rng/unix/mc_getrandom_stubs.c
@@ -18,7 +18,8 @@
 # endif
 
 void raw_getrandom (uint8_t *data, uint32_t len) {
-  int r, off = 0;
+  size_t off = 0;
+  ssize_t r = 0;
   while (off < len) {
     r = getrandom(data + off, len - off, 0);
     if (r < 0 && errno == EINTR) continue;

--- a/rng/unix/mc_getrandom_stubs.c
+++ b/rng/unix/mc_getrandom_stubs.c
@@ -22,9 +22,11 @@ void raw_getrandom (uint8_t *data, uint32_t len) {
   ssize_t r = 0;
   while (off < len) {
     r = getrandom(data + off, len - off, 0);
-    if (r < 0 && errno == EINTR) continue;
-    else if (r < 0) uerror("getrandom", Nothing);
-    off += r;
+    if (r == -1) {
+      if (errno == EINTR) continue;
+      else uerror("getrandom", Nothing);
+    }
+    off += (size_t)r;
   }
 }
 #elif (defined(__FreeBSD__) || defined(__FreeBSD_kernel__) || defined(__OpenBSD__) || defined(__APPLE__))
@@ -39,7 +41,7 @@ void raw_getrandom (uint8_t *data, uint32_t len) {
   size_t rlen = 0;
   for (uint32_t i = 0; i <= len; i += 256) {
     rlen = MIN(256, len - i);
-    if (getentropy(data + i, rlen) < 0) uerror("getentropy", Nothing);
+    if (getentropy(data + i, rlen) == -1) uerror("getentropy", Nothing);
   }
 }
 #elif (defined(_WIN32))

--- a/src/native/des_generic.c
+++ b/src/native/des_generic.c
@@ -59,7 +59,7 @@ static unsigned char pc2[48] = {
 	40, 51, 30, 36, 46, 54,	29, 39, 50, 44, 32, 47,
 	43, 48, 38, 55, 33, 52,	45, 41, 49, 35, 28, 31 };
 
-void mc_deskey(unsigned char *key, short edf) /* Thanks to James Gillogly & Phil Karn! */
+void mc_deskey(unsigned char key[8], short edf) /* Thanks to James Gillogly & Phil Karn! */
 {
 	int i, j, l, m, n;
 	unsigned char pc1m[56], pcr[56];
@@ -94,8 +94,7 @@ void mc_deskey(unsigned char *key, short edf) /* Thanks to James Gillogly & Phil
 	return;
 	}
 
-static void cookey(raw1)
-unsigned long *raw1;
+static void cookey(unsigned long *raw1)
 {
 	unsigned long *cook, *raw0;
 	unsigned long dough[32];
@@ -117,8 +116,7 @@ unsigned long *raw1;
 	return;
 	}
 
-void mc_cpkey(into)
-unsigned long *into;
+void mc_cpkey(unsigned long into[32])
 {
 	unsigned long *from, *endp;
 
@@ -127,8 +125,7 @@ unsigned long *into;
 	return;
 	}
 
-void mc_usekey(from)
-unsigned long *from;
+void mc_usekey(unsigned long from[32])
 {
 	unsigned long *to, *endp;
 
@@ -137,8 +134,7 @@ unsigned long *from;
 	return;
 	}
 
-void mc_des(inblock, outblock)
-unsigned char *inblock, *outblock;
+void mc_des(unsigned char inblock[8], unsigned char outblock[8])
 {
 	unsigned long work[2];
 
@@ -149,9 +145,7 @@ unsigned char *inblock, *outblock;
 	}
 
 
-static void scrunch(outof, into)
-unsigned char *outof;
-unsigned long *into;
+static void scrunch(unsigned char *outof, unsigned long *into)
 {
 	*into 	 = (*outof++ & 0xffL) << 24;
 	*into 	|= (*outof++ & 0xffL) << 16;
@@ -165,9 +159,7 @@ unsigned long *into;
 	}
 
 
-static void unscrun(outof, into)
-unsigned long *outof;
-unsigned char *into;
+static void unscrun(unsigned long *outof, unsigned char *into)
 {
 	*into++ = (*outof >> 24) & 0xffL;
 	*into++ = (*outof >> 16) & 0xffL;
@@ -324,8 +316,7 @@ static unsigned long SP8[64] = {
 	0x10041040L, 0x00041000L, 0x00041000L, 0x00001040L,
 	0x00001040L, 0x00040040L, 0x10000000L, 0x10041000L };
 
-static void desfunc(block, keys)
-unsigned long *block, *keys;
+static void desfunc(unsigned long *block, unsigned long *keys)
 {
 	unsigned long fval, work, right, leftt;
 	int round;
@@ -413,8 +404,7 @@ void mc_des2key(unsigned char hexkey[16], short mode) /* stomps on Kn3 too */
 	return;
 	}
 
-void mc_Ddes(from, into)
-unsigned char *from, *into;		/* unsigned char[8] */
+void mc_Ddes(unsigned char from[8], unsigned char into[8])
 {
 	unsigned long work[2];
 
@@ -426,9 +416,7 @@ unsigned char *from, *into;		/* unsigned char[8] */
 	return;
 	}
 
-void mc_D2des(from, into)
-unsigned char *from;			/* unsigned char[16] */
-unsigned char *into;			/* unsigned char[16] */
+void mc_D2des(unsigned char from[16], unsigned char into[16])
 {
 	unsigned long *right, *l1, swap;
 	unsigned long leftt[2], bufR[2];
@@ -454,9 +442,7 @@ unsigned char *into;			/* unsigned char[16] */
 	return;
 	}
 
-void mc_makekey(aptr, kptr)
-char *aptr;				/* NULL-terminated  */
-unsigned char *kptr;		/* unsigned char[8] */
+void mc_makekey(char *aptr /* NULL-terminated */, unsigned char kptr[8])
 {
 	unsigned char *store;
 	int first, i;
@@ -479,9 +465,7 @@ unsigned char *kptr;		/* unsigned char[8] */
 	return;
 	}
 
-void mc_make2key(aptr, kptr)
-char *aptr;				/* NULL-terminated   */
-unsigned char *kptr;		/* unsigned char[16] */
+void mc_make2key(char *aptr /* NULL-terminated */, unsigned char kptr[16])
 {
 	unsigned char *store;
 	int first, i;
@@ -506,8 +490,7 @@ unsigned char *kptr;		/* unsigned char[16] */
 
 #ifndef D3_DES	/* D2_DES only */
 
-void mc_cp2key(into)
-unsigned long *into;	/* unsigned long[64] */
+void mc_cp2key(unsigned long into[64])
 {
 	unsigned long *from, *endp;
 
@@ -518,8 +501,7 @@ unsigned long *into;	/* unsigned long[64] */
 	return;
 	}
 
-void mc_use2key(from)				/* stomps on Kn3 too */
-unsigned long *from;	/* unsigned long[64] */
+void mc_use2key(unsigned long from[64])	/* stomps on Kn3 too */
 {
 	unsigned long *to, *endp;
 
@@ -556,8 +538,7 @@ void mc_des3key(unsigned char hexkey[24], short mode)
 	return;
 	}
 
-void mc_cp3key(into)
-unsigned long *into;	/* unsigned long[96] */
+void mc_cp3key(unsigned long into[96])
 {
 	unsigned long *from, *endp;
 
@@ -570,8 +551,7 @@ unsigned long *into;	/* unsigned long[96] */
 	return;
 	}
 
-void mc_use3key(from)
-unsigned long *from;	/* unsigned long[96] */
+void mc_use3key(unsigned long from[96])
 {
 	unsigned long *to, *endp;
 
@@ -584,11 +564,7 @@ unsigned long *from;	/* unsigned long[96] */
 	return;
 	}
 
-static void D3des(unsigned char *, unsigned char *);
-
-static void D3des(from, into)	/* amateur theatrics */
-unsigned char *from;			/* unsigned char[24] */
-unsigned char *into;			/* unsigned char[24] */
+static void D3des(unsigned char from[24], unsigned char into[24])	/* amateur theatrics */
 {
 	unsigned long swap, leftt[2], middl[2], right[2];
 
@@ -622,9 +598,7 @@ unsigned char *into;			/* unsigned char[24] */
 	return;
 	}
 
-void mc_make3key(aptr, kptr)
-char *aptr;				/* NULL-terminated   */
-unsigned char *kptr;		/* unsigned char[24] */
+void mc_make3key(char *aptr /* NULL-terminated   */, unsigned char kptr[24])
 {
 	unsigned char *store;
 	int first, i;

--- a/src/native/des_generic.h
+++ b/src/native/des_generic.h
@@ -36,25 +36,25 @@ typedef union {
 	unsigned char dbyte[16];
 	} M68K2;
 
-extern void mc_deskey(unsigned char *, short);
+extern void mc_deskey(unsigned char [8], short);
 /*		      hexkey[8]     MODE
  * Sets the internal key register according to the hexadecimal
  * key contained in the 8 bytes of hexkey, according to the DES,
  * for encryption or decryption according to MODE.
  */
 
-extern void mc_usekey(unsigned long *);
+extern void mc_usekey(unsigned long [32]);
 /*		    cookedkey[32]
  * Loads the internal key register with the data in cookedkey.
  */
 
-extern void mc_cpkey(unsigned long *);
+extern void mc_cpkey(unsigned long [32]);
 /*		   cookedkey[32]
  * Copies the contents of the internal key register into the storage
  * located at &cookedkey[0].
  */
 
-extern void mc_des(unsigned char *, unsigned char *);
+extern void mc_des(unsigned char [8], unsigned char [8]);
 /*		    from[8]	      to[8]
  * Encrypts/Decrypts (according to the key currently loaded in the
  * internal key register) one block of eight bytes at address 'from'
@@ -72,21 +72,21 @@ extern void mc_des2key(unsigned char [16], short);
  * NOTE: this clobbers all three key registers!
  */
 
-extern void mc_Ddes(unsigned char *, unsigned char *);
+extern void mc_Ddes(unsigned char [8], unsigned char [8]);
 /*		    from[8]	      to[8]
  * Encrypts/Decrypts (according to the keyS currently loaded in the
  * internal key registerS) one block of eight bytes at address 'from'
  * into the block at address 'to'.  They can be the same.
  */
 
-extern void mc_D2des(unsigned char *, unsigned char *);
+extern void mc_D2des(unsigned char [16], unsigned char [16]);
 /*		    from[16]	      to[16]
  * Encrypts/Decrypts (according to the keyS currently loaded in the
  * internal key registerS) one block of SIXTEEN bytes at address 'from'
  * into the block at address 'to'.  They can be the same.
  */
 
-extern void mc_makekey(char *, unsigned char *);
+extern void mc_makekey(char *, unsigned char [8]);
 /*		*password,	single-length key[8]
  * With a double-length default key, this routine hashes a NULL-terminated
  * string into an eight-byte random-looking key, suitable for use with the
@@ -94,7 +94,7 @@ extern void mc_makekey(char *, unsigned char *);
  */
 
 #define makeDkey(a,b)	mc_make2key((a),(b))
-extern void mc_make2key(char *, unsigned char *);
+extern void mc_make2key(char *, unsigned char [16]);
 /*		*password,	double-length key[16]
  * With a double-length default key, this routine hashes a NULL-terminated
  * string into a sixteen-byte random-looking key, suitable for use with the
@@ -106,13 +106,13 @@ extern void mc_make2key(char *, unsigned char *);
 #define useDkey(a)	mc_use2key((a))
 #define cpDkey(a)	mc_cp2key((a))
 
-extern void mc_use2key(unsigned long *);
+extern void mc_use2key(unsigned long [64]);
 /*		    cookedkey[64]
  * Loads the internal key registerS with the data in cookedkey.
  * NOTE: this clobbers all three key registers!
  */
 
-extern void mc_cp2key(unsigned long *);
+extern void mc_cp2key(unsigned long [64]);
 /*		   cookedkey[64]
  * Copies the contents of the internal key registerS into the storage
  * located at &cookedkey[0].
@@ -130,18 +130,18 @@ extern void mc_des3key(unsigned char [24], short);
  * for DOUBLE encryption or decryption according to MODE.
  */
 
-extern void mc_use3key(unsigned long *);
+extern void mc_use3key(unsigned long [96]);
 /*		    cookedkey[96]
  * Loads the 3 internal key registerS with the data in cookedkey.
  */
 
-extern void mc_cp3key(unsigned long *);
+extern void mc_cp3key(unsigned long [96]);
 /*		   cookedkey[96]
  * Copies the contents of the 3 internal key registerS into the storage
  * located at &cookedkey[0].
  */
 
-extern void mc_make3key(char *, unsigned char *);
+extern void mc_make3key(char *, unsigned char [24]);
 /*		*password,	triple-length key[24]
  * With a triple-length default key, this routine hashes a NULL-terminated
  * string into a twenty-four-byte random-looking key, suitable for use with

--- a/src/native/entropy_cpu_stubs.c
+++ b/src/native/entropy_cpu_stubs.c
@@ -59,7 +59,7 @@
   __asm__ __volatile__ ("mrc p15, 0, %0, c9, c13, 0": "=r" (res));
 */
 #if defined(__ocaml_freestanding__) || defined(__ocaml_solo5__)
-static inline uint32_t read_virtual_count ()
+static inline uint32_t read_virtual_count (void)
 {
   uint32_t c_lo, c_hi;
   __asm__ __volatile__("mrrc p15, 1, %0, %1, c14":"=r"(c_lo), "=r"(c_hi));
@@ -72,7 +72,7 @@ https://chromium.googlesource.com/external/gperftools/+/master/src/base/cycleclo
    a kernel module also in user mode). Use clock_gettime as fallback.
  */
 #include <time.h>
-static inline uint32_t read_virtual_count ()
+static inline uint32_t read_virtual_count (void)
 {
   uint32_t pmccntr;
   uint32_t pmuseren;
@@ -136,7 +136,7 @@ static inline uint64_t getticks(void)
 #endif
 
 #if defined (__mips__)
-static inline unsigned long get_count() {
+static inline unsigned long get_count(void) {
   unsigned long count;
   __asm__ __volatile__ ("rdhwr %[rt], $2" : [rt] "=d" (count));
   return count;
@@ -174,7 +174,7 @@ static int __cpu_rng = RNG_NONE;
 
 #define RETRIES 10
 
-static void detect () {
+static void detect (void) {
 #ifdef __mc_ENTROPY__
   random_t r = 0;
 


### PR DESCRIPTION
Modern compilers emit warnings when using K&R C function prototypes and functions taking `()` instead of void for no parameters.