### PR TITLE
mirage-crypto-rng-eio: use monotonic clock from eio's environment instead of mtime 

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+## dev
+
+* mirage-crypto-rng-eio: improve portability by using eio 0.7's monotonic clock
+  interface instead of mtime.clock.os. (@TheLortex)
+
 ## v0.11.1 (2023-03-09)
 
 * BUGFIX Chacha20 decrypt and encrypt with empty data (previously lead to

--- a/mirage-crypto-rng-eio.opam
+++ b/mirage-crypto-rng-eio.opam
@@ -15,7 +15,7 @@ build: [ ["dune" "subst"] {dev}
 depends: [
   "ocaml" {>= "5.0.0"}
   "dune" {>= "2.7"}
-  "eio" {>= "0.3"}
+  "eio" {>= "0.7"}
   "cstruct" {>= "6.0.0"}
   "logs"
   "mirage-crypto-rng" {=version}

--- a/rng/eio/dune
+++ b/rng/eio/dune
@@ -1,4 +1,4 @@
 (library
  (name mirage_crypto_rng_eio)
  (public_name mirage-crypto-rng-eio)
- (libraries eio cstruct logs mirage-crypto-rng duration mtime.clock.os))
+ (libraries eio cstruct logs mirage-crypto-rng duration))

--- a/rng/eio/dune
+++ b/rng/eio/dune
@@ -1,4 +1,4 @@
 (library
  (name mirage_crypto_rng_eio)
  (public_name mirage-crypto-rng-eio)
- (libraries eio cstruct logs mirage-crypto-rng duration))
+ (libraries eio cstruct logs mirage-crypto-rng duration mtime))

--- a/rng/eio/mirage_crypto_rng_eio.ml
+++ b/rng/eio/mirage_crypto_rng_eio.ml
@@ -3,6 +3,7 @@ open Mirage_crypto_rng
 
 type env = <
   clock: Eio.Time.clock;
+  mono: Eio.Time.Mono.t;
   secure_random: Eio.Flow.source;
 >
 
@@ -75,7 +76,7 @@ let run
               Entropy.[ bootstrap ; whirlwind_bootstrap ; bootstrap ; getrandom_init env ] in
             List.mapi (fun i f -> f i) init |> Cstruct.concat
           in
-          let rng = create ?g ~seed ~time:Mtime_clock.elapsed_ns generator in
+          let rng = create ?g ~seed ~time:(fun () -> env#mono#now |> Mtime.to_uint64_ns) generator in
           set_default_generator rng;
           let source = Entropy.register_source "getrandom" in
           let feed_entropy () = periodically_feed_entropy env (Int64.mul sleep 10L) source in

--- a/rng/eio/mirage_crypto_rng_eio.ml
+++ b/rng/eio/mirage_crypto_rng_eio.ml
@@ -3,7 +3,7 @@ open Mirage_crypto_rng
 
 type env = <
   clock: Eio.Time.clock;
-  mono: Eio.Time.Mono.t;
+  mono_clock: Eio.Time.Mono.t;
   secure_random: Eio.Flow.source;
 >
 
@@ -76,7 +76,10 @@ let run
               Entropy.[ bootstrap ; whirlwind_bootstrap ; bootstrap ; getrandom_init env ] in
             List.mapi (fun i f -> f i) init |> Cstruct.concat
           in
-          let rng = create ?g ~seed ~time:(fun () -> env#mono#now |> Mtime.to_uint64_ns) generator in
+          let time () =
+            Eio.Stdenv.mono_clock env |> Eio.Time.Mono.now |> Mtime.to_uint64_ns
+          in
+          let rng = create ?g ~seed ~time generator in
           set_default_generator rng;
           let source = Entropy.register_source "getrandom" in
           let feed_entropy () = periodically_feed_entropy env (Int64.mul sleep 10L) source in

--- a/rng/eio/mirage_crypto_rng_eio.mli
+++ b/rng/eio/mirage_crypto_rng_eio.mli
@@ -6,7 +6,7 @@
 
 type env = <
   clock: Eio.Time.clock;
-  mono: Eio.Time.Mono.t;
+  mono_clock: Eio.Time.Mono.t;
   secure_random: Eio.Flow.source;
   >
 

--- a/rng/eio/mirage_crypto_rng_eio.mli
+++ b/rng/eio/mirage_crypto_rng_eio.mli
@@ -6,6 +6,7 @@
 
 type env = <
   clock: Eio.Time.clock;
+  mono: Eio.Time.Mono.t;
   secure_random: Eio.Flow.source;
   >
 


### PR DESCRIPTION
This PR improves mirage-crypto-rng-eio's portability by making it not depend on system features. 

Instead of depending on mtime.clock.os, the user should provide a monotonic clock implementation as part of the `env`ironment variable.