### PR TITLE
Build powerpc64 with -Wno-stringop-overflow tests due to false positives

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+## dev
+
+* Build fix on PowerPC64 due to spurious gcc warnings for stringop overflow.
+
 ## v0.11.1 (2023-03-09)
 
 * BUGFIX Chacha20 decrypt and encrypt with empty data (previously lead to

--- a/config/cfg.ml
+++ b/config/cfg.ml
@@ -7,11 +7,12 @@ let () =
       Configurator.V1.C_define.import
         c
         ~includes:[]
-        [("__x86_64__", Switch); ("__i386__", Switch)]
+        [("__x86_64__", Switch); ("__i386__", Switch); ("__powerpc64__", Switch)]
     in
     match defines with
     | (_, Switch true) :: _ -> `x86_64
     | _ :: (_, Switch true) :: _ -> `x86
+    | _ :: _ :: (_, Switch true) :: _ -> `ppc64
     | _ -> `unknown
   in
   let accelerate_flags =
@@ -24,7 +25,12 @@ let () =
     | `x86_64 | `x86 -> [ "-DENTROPY"; "-mrdrnd"; "-mrdseed" ]
     | _ -> []
   in
+  let warn_flags =
+   match arch with
+   | `ppc64 -> [ "-Wno-stringop-overflow" ] (* gcc bug https://bugs.launchpad.net/ubuntu/+source/gcc-12/+bug/2013140 *)
+   | _ -> []
+  in
   let flags = std_flags @ ent_flags in
-  let opt_flags = flags @ accelerate_flags in
+  let opt_flags = flags @ accelerate_flags @ warn_flags in
   Configurator.V1.Flags.write_sexp "cflags_optimized.sexp" opt_flags;
   Configurator.V1.Flags.write_sexp "cflags.sexp" flags


### PR DESCRIPTION
They do seem to be false positives when I look through the code, and it is also independently reported here:
https://bugs.launchpad.net/ubuntu/+source/gcc-12/+bug/2013140

The warnings disappear at -O2, but compilation and tests seem fine at -O3 with the warning disabled, so I chose to keep it at -O3.

An example warning is:

```
In file included from native/poly1305-donna.c:11:
native/poly1305-donna.c: In function ‘mc_poly1305_update’:
native/poly1305-donna-64.h:24:23: note: at offset 28 into destination object ‘buffer’ of size 16
   24 |         unsigned char buffer[poly1305_block_size];
      |                       ^~~~~~
In function ‘poly1305_update’,
    inlined from ‘mc_poly1305_update’ at native/poly1305-donna.c:60:3:
native/poly1305-donna.c:48:54: error: writing 1 byte into a region of size 0 [-Werror=stringop-overflow=]
   48 |                         st->buffer[st->leftover + i] = m[i];
      |                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~
```

Spotted while testing https://github.com/ocaml/ocaml/pull/12276