### PR TITLE
Update to Eio 0.12

### DIFF
--- a/mirage-crypto-rng-eio.opam
+++ b/mirage-crypto-rng-eio.opam
@@ -15,7 +15,7 @@ build: [ ["dune" "subst"] {dev}
 depends: [
   "ocaml" {>= "5.0.0"}
   "dune" {>= "2.7"}
-  "eio" {>= "0.7"}
+  "eio" {>= "0.12"}
   "cstruct" {>= "6.0.0"}
   "logs"
   "mirage-crypto-rng" {=version}

--- a/rng/eio/mirage_crypto_rng_eio.ml
+++ b/rng/eio/mirage_crypto_rng_eio.ml
@@ -1,11 +1,11 @@
-
 open Mirage_crypto_rng
 
-type env = <
-  clock: Eio.Time.clock;
-  mono_clock: Eio.Time.Mono.t;
-  secure_random: Eio.Flow.source;
->
+type 'a env = <
+  clock: [> ] Eio.Time.clock;
+  mono_clock: [> ] Eio.Time.Mono.t;
+  secure_random: [> ] Eio.Flow.source;
+  ..
+> as 'a
 
 let src = Logs.Src.create "mirage-crypto-rng-eio" ~doc:"Mirage crypto RNG Eio"
 module Log = (val Logs.src_log src: Logs.LOG)

--- a/rng/eio/mirage_crypto_rng_eio.mli
+++ b/rng/eio/mirage_crypto_rng_eio.mli
@@ -4,11 +4,12 @@
     [Eio.Stdenv.secure_random] is used as the [getrandom()] implementation.
 *)
 
-type env = <
-  clock: Eio.Time.clock;
-  mono_clock: Eio.Time.Mono.t;
-  secure_random: Eio.Flow.source;
-  >
+type 'a env = <
+  clock: [> ]Eio.Time.clock;
+  mono_clock: [> ]Eio.Time.Mono.t;
+  secure_random: [> ] Eio.Flow.source;
+  ..
+> as 'a
 
 (** [run ~g ~sleep gen env fn] will bring the RNG into a working state. The argument
     [sleep] is measured in ns (default 1s), and is used to sleep between collection
@@ -36,5 +37,5 @@ val run
   :  ?g:'a
   -> ?sleep:int64
   -> 'a Mirage_crypto_rng.generator
-  -> <env; ..>
+  -> _ env
   -> (unit -> 'b) -> 'b


### PR DESCRIPTION
Eio 0.12 no longer uses OCaml objects for OS resources. This requires a minor change to mirage-crypto-rng-eio to use the new variant types instead.

(tested using my [Eio 0.12 branch of ocaml-tls](https://github.com/talex5/ocaml-tls/tree/eio))