### PR TITLE
avoid stringop-overflow warning on ppc64, s390x

### DIFF
--- a/config/cfg.ml
+++ b/config/cfg.ml
@@ -7,11 +7,14 @@ let () =
       Configurator.V1.C_define.import
         c
         ~includes:[]
-        [("__x86_64__", Switch); ("__i386__", Switch)]
+        [("__x86_64__", Switch); ("__i386__", Switch); ("__powerpc64__", Switch);
+         ("__s390x__", Switch)]
     in
     match defines with
     | (_, Switch true) :: _ -> `x86_64
     | _ :: (_, Switch true) :: _ -> `x86
+    | _ :: _ :: (_, Switch true) :: _ -> `ppc64
+    | _ :: _ :: _ :: (_, Switch true) :: _ -> `s390x
     | _ -> `unknown
   in
   let accelerate_flags =
@@ -24,7 +27,14 @@ let () =
     | `x86_64 | `x86 -> [ "-DENTROPY"; "-mrdrnd"; "-mrdseed" ]
     | _ -> []
   in
+  let warn_flags =
+    (* See #178, there may be false positives on ppc&s390 with no-stringop-overflow *)
+    match arch with
+    | `ppc64 | `s390x -> [ "-Wno-stringop-overflow"; "-Werror" ]
+    | _ -> [ "-Werror" ]
+  in
   let flags = std_flags @ ent_flags in
   let opt_flags = flags @ accelerate_flags in
   Configurator.V1.Flags.write_sexp "cflags_optimized.sexp" opt_flags;
-  Configurator.V1.Flags.write_sexp "cflags.sexp" flags
+  Configurator.V1.Flags.write_sexp "cflags.sexp" flags;
+  Configurator.V1.Flags.write_sexp "cflags_warn.sexp" warn_flags

--- a/ec/dune
+++ b/ec/dune
@@ -13,11 +13,11 @@
 
 (env
  (dev
-  (c_flags (-Werror))))
+  (c_flags (:include cflags_warn.sexp))))
 
 (include_subdirs unqualified)
 
 (rule
- (targets cflags_optimized.sexp)
+ (targets cflags_optimized.sexp cflags_warn.sexp)
  (action
   (run ../config/cfg.exe)))

--- a/rng/unix/dune
+++ b/rng/unix/dune
@@ -8,6 +8,11 @@
  (action
   (run ./discover.exe)))
 
+(rule
+ (targets cflags_warn.sexp)
+ (action
+  (run ../../config/cfg.exe)))
+
 (library
  (name mirage_crypto_rng_unix)
  (public_name mirage-crypto-rng.unix)
@@ -21,4 +26,4 @@
 
 (env
  (dev
-  (c_flags (-Werror))))
+  (c_flags (:include cflags_warn.sexp))))

--- a/src/dune
+++ b/src/dune
@@ -21,11 +21,11 @@
 
 (env
  (dev
-  (c_flags (-Werror))))
+  (c_flags (:include cflags_warn.sexp))))
 
 (include_subdirs unqualified)
 
 (rule
- (targets cflags.sexp cflags_optimized.sexp)
+ (targets cflags.sexp cflags_optimized.sexp cflags_warn.sexp)
  (action
   (run ../config/cfg.exe)))


### PR DESCRIPTION
superseeds #178