### PR TITLE
on macos (arm64), avoid -O3 due to miscompilations

### DIFF
--- a/config/cfg.ml
+++ b/config/cfg.ml
@@ -1,4 +1,4 @@
-let std_flags = ["--std=c11"; "-Wall"; "-Wextra"; "-Wpedantic"; "-O3"]
+let std_flags = ["--std=c11"; "-Wall"; "-Wextra"; "-Wpedantic"]
 
 let () =
   let c = Configurator.V1.create "mirage-crypto" in
@@ -8,13 +8,25 @@ let () =
         c
         ~includes:[]
         [("__x86_64__", Switch); ("__i386__", Switch); ("__powerpc64__", Switch);
-         ("__s390x__", Switch)]
+         ("__s390x__", Switch); ("__aarch64__", Switch)]
     in
     match defines with
     | (_, Switch true) :: _ -> `x86_64
     | _ :: (_, Switch true) :: _ -> `x86
     | _ :: _ :: (_, Switch true) :: _ -> `ppc64
     | _ :: _ :: _ :: (_, Switch true) :: _ -> `s390x
+    | _ :: _ :: _ :: _ :: (_, Switch true) :: _ -> `arm64
+    | _ -> `unknown
+  in
+  let os =
+    let defines =
+      Configurator.V1.C_define.import
+        c
+        ~includes:[]
+        [("__APPLE__", Switch)]
+    in
+    match defines with
+    | (_, Switch true) :: _ -> `macos
     | _ -> `unknown
   in
   let accelerate_flags =
@@ -33,7 +45,16 @@ let () =
     | `ppc64 | `s390x -> [ "-Wno-stringop-overflow"; "-Werror" ]
     | _ -> [ "-Werror" ]
   in
-  let flags = std_flags @ ent_flags in
+  let optimization = match arch, os with
+    | `arm64, `macos ->
+      let res = Configurator.V1.Process.run c "cc" ["-dumpversion"] in
+      if String.trim res.stdout = "14.0.3" then
+        "-O0" (* macOS instcombine miscompilation with clang 14.0.3 *)
+      else
+        "-O3"
+    | _ -> "-O3"
+  in
+  let flags = optimization :: std_flags @ ent_flags in
   let opt_flags = flags @ accelerate_flags in
   Configurator.V1.Flags.write_sexp "cflags_optimized.sexp" opt_flags;
   Configurator.V1.Flags.write_sexp "cflags.sexp" flags;


### PR DESCRIPTION
this is a big hammer which makes the code slower.

but better slow code than not working code. there's hope that apple will eventually fix their llvm.