### PR TITLE
Allocate less in Fortuna

### DIFF
--- a/rng/fortuna.ml
+++ b/rng/fortuna.ml
@@ -102,12 +102,15 @@ let generate ~g bytes =
            chunk (generate_rekey ~g n' :: acc) (n - n') in
   Cstruct.concat @@ chunk [] bytes
 
-let add ~g (source, _) ~pool data =
-  let pool   = pool land (pools - 1)
-  and source = source land 0xff in
-  let header = Cs.of_bytes [ source ; Cstruct.length data ] in
-  g.pools.(pool) <- SHAd256.feedi g.pools.(pool) (iter2 header data);
-  if pool = 0 then g.pool0_size <- g.pool0_size + Cstruct.length data
+let add ~g (source, _) ~pool =
+  let buf = Cstruct.create_unsafe 2 in
+  fun data ->
+    let pool   = pool land (pools - 1)
+    and source = source land 0xff in
+    Cstruct.set_uint8 buf 0 source;
+    Cstruct.set_uint8 buf 1 (Cstruct.length data);
+    g.pools.(pool) <- SHAd256.feedi g.pools.(pool) (iter2 buf data);
+    if pool = 0 then g.pool0_size <- g.pool0_size + Cstruct.length data
 
 (* XXX
  * Schneier recommends against using generator-imposed pool-seeding schedule

--- a/rng/fortuna.ml
+++ b/rng/fortuna.ml
@@ -102,14 +102,14 @@ let generate ~g bytes =
            chunk (generate_rekey ~g n' :: acc) (n - n') in
   Cstruct.concat @@ chunk [] bytes
 
-let add ~g (source, _) ~pool =
-  let buf = Cstruct.create_unsafe 2 in
-  fun data ->
+let _buf = Cstruct.create_unsafe 2
+
+let add ~g (source, _) ~pool data =
     let pool   = pool land (pools - 1)
     and source = source land 0xff in
-    Cstruct.set_uint8 buf 0 source;
-    Cstruct.set_uint8 buf 1 (Cstruct.length data);
-    g.pools.(pool) <- SHAd256.feedi g.pools.(pool) (iter2 buf data);
+    Cstruct.set_uint8 _buf 0 source;
+    Cstruct.set_uint8 _buf 1 (Cstruct.length data);
+    g.pools.(pool) <- SHAd256.feedi g.pools.(pool) (iter2 _buf data);
     if pool = 0 then g.pool0_size <- g.pool0_size + Cstruct.length data
 
 (* XXX


### PR DESCRIPTION
@palainp observed lots of 2 byte allocations (with malloc, via bigarray). The root cause is the `add` function in our Fortuna module.

This PR uses instead a global pre-allocated buffer. This is likely fine for OCaml 4, but will be troublesome (a data race) when OCaml 5 (see #186) is considered, or any other multi-threading preemption setup.

It is not 100% clear how to move forward. One part is to document "mirage-crypto is not SMP safe", and if someone wants to use it in such a system, they should guard functions with mutexes.

What does the way ahead mean? We have observed that using "cstruct.t" may have been not the wisest choice from early on, and settling on bytes/string would be more wise (in terms of GC friendlyness). We also observe that a "domain-local variable" (i.e. `__thread` in C) is missing in OCaml AFAICT. Keeping performance in mind, maybe we should merge this as an intermediate stop-gap solution, then move on revising the API to use string/bytes (at least internally), and only then figure out a solution for the multicore stuff.

In related news, there's ongoing work for thread-local storage in OCaml 5 (https://github.com/ocaml/ocaml/pull/12724 https://github.com/ocaml/ocaml/pull/12889 https://github.com/ocaml/ocaml/issues/12677) -- looks like 5.3 may have such a thing. Considering my time and energy, maybe mark mirage-crypto* as not available for OCaml 5 (until there's a thread local storage story and we fix the code) is the way to go? WDYT?