### PR TITLE
Add NetBSD to the list of BSD OS in define

### DIFF
--- a/rng/unix/mc_getrandom_stubs.c
+++ b/rng/unix/mc_getrandom_stubs.c
@@ -29,7 +29,7 @@ void raw_getrandom (uint8_t *data, uint32_t len) {
     off += (size_t)r;
   }
 }
-#elif (defined(__FreeBSD__) || defined(__FreeBSD_kernel__) || defined(__DragonFly__)  || defined(__OpenBSD__) || defined(__APPLE__))
+#elif (defined(__FreeBSD__) || defined(__FreeBSD_kernel__) || defined(__DragonFly__)  || defined(__OpenBSD__) || defined(__APPLE__)) || defined(__NetBSD__)
 // on BSD and macOS, loop (in pieces of 256) getentropy
 #if defined(__APPLE__)
 // on macOS, getentropy is defined in sys/random.h (on BSD in unistd.h)


### PR DESCRIPTION
I currently working on getting Octez (Tezos) to work on NetBSD. Today I successfully built mirage-crypto-rng with this change. I have not been able to do much testing.