### PR TITLE
riscv64: Replace rdcycle64 with rdtime64

### DIFF
--- a/src/native/entropy_cpu_stubs.c
+++ b/src/native/entropy_cpu_stubs.c
@@ -118,10 +118,15 @@ static inline uint64_t read_cycle_counter(void)
 #endif
 
 #if defined (__riscv) && (64 == __riscv_xlen)
-static inline uint64_t rdtime64(void)
+//since rdcycle is a privileged instruction since linux 6.6, we use rdtime when in user-space
+static inline uint64_t cycle_count(void)
 {
   uint64_t rval;
+#if defined(__ocaml_freestanding__) || defined(__ocaml_solo5__)
+  __asm__ __volatile__ ("rdcycle %0" : "=r" (rval));
+#else
   __asm__ __volatile__ ("rdtime %0" : "=r" (rval));
+#endif /* __ocaml_freestanding__ || __ocaml_solo5__ */
   return rval;
 }
 #endif
@@ -160,7 +165,7 @@ CAMLprim value mc_cycle_counter (value __unused(unit)) {
 #elif defined(__powerpc64__)
   return Val_long (read_cycle_counter ());
 #elif defined(__riscv) && (64 == __riscv_xlen)
-  return Val_long (rdtime64 ());
+  return Val_long (cycle_count ());
 #elif defined (__s390x__)
   return Val_long (getticks ());
 #elif defined(__mips__)

--- a/src/native/entropy_cpu_stubs.c
+++ b/src/native/entropy_cpu_stubs.c
@@ -118,10 +118,10 @@ static inline uint64_t read_cycle_counter(void)
 #endif
 
 #if defined (__riscv) && (64 == __riscv_xlen)
-static inline uint64_t rdcycle64(void)
+static inline uint64_t rdtime64(void)
 {
   uint64_t rval;
-  __asm__ __volatile__ ("rdcycle %0" : "=r" (rval));
+  __asm__ __volatile__ ("rdtime %0" : "=r" (rval));
   return rval;
 }
 #endif
@@ -160,7 +160,7 @@ CAMLprim value mc_cycle_counter (value __unused(unit)) {
 #elif defined(__powerpc64__)
   return Val_long (read_cycle_counter ());
 #elif defined(__riscv) && (64 == __riscv_xlen)
-  return Val_long (rdcycle64 ());
+  return Val_long (rdtime64 ());
 #elif defined (__s390x__)
   return Val_long (getticks ());
 #elif defined(__mips__)


### PR DESCRIPTION
rdcycle is privileged since kernel 6.6, resulting in SIGILL:
https://buildd.debian.org/status/fetch.php?pkg=ocaml-mirage-crypto&arch=riscv64&ver=0.11.2-1%2Bb3&stamp=1708088363&raw=0