### PR TITLE
mirage-crypto-ec: warn about power/timing analysis on k in sign

### DIFF
--- a/ec/mirage_crypto_ec.mli
+++ b/ec/mirage_crypto_ec.mli
@@ -112,6 +112,12 @@ module type Dsa = sig
       deterministic construction from RFC 6979. The result is a pair of [r]
       and [s].
 
+      Warning: there {{:https://www.hertzbleed.com/2h2b.pdf}are}
+      {{:https://www.hertzbleed.com/hertzbleed.pdf}attacks} that recover the
+      private key from a power and timing analysis of the RFC 6979 computation
+      of [k] - thus it is advised to provide a good nonce ([k]) explicitly,
+      which is independent of key and digest.
+
       @raise Invalid_argument if [k] is not suitable or not in range.
       @raise Message_too_long if the bit size of [msg] exceeds the curve. *)
 


### PR DESCRIPTION
//cc @edwintorok since you mentioned this in https://discuss.systems/@edwintorok/111925959867297453 - would this warning suite you?

I'm still unsure what advise to give to be honest: on the one side, it looks that these attacks are local -- thus in a multi-tenant setup, just don't do crypto ;) -- on the other side, asking a developer to select a `k` is something they can easily get wrong as well.

So, below the line: should we switch by default to a random `k`? Should we warn about multi-tenant systems explicitly?

The mitigation you mention "validating that the ciphertext (public key) consists of a pair of linearly independent points of the correct order 3e" is obviously something we can implement (enabled by default) -- maybe measure the performance impact?

Also, you mention blinding, and I'm curious what is in mind -- in our (normal, non-EC) DSA sign_z code we have:
```OCaml
  (* normal DSA sign is: s = k^-1 * (z + r * x) mod q *)
  (* we apply blinding where possible and compute:
     s = k^-1 * b^-1 * (b * z + b * r * x) mod q
     see https://github.com/openssl/openssl/pull/6524 for further details *)
```

Should we do the same in ECDSA sign?