### PR TITLE
benchmarks: provide a digest benchmark which uses various implementations

### DIFF
--- a/bench/digests.ml
+++ b/bench/digests.ml
@@ -1,0 +1,144 @@
+open Helper
+
+let print_result_table alg rs =
+  if rs = [] then
+    print_endline "rs is empty"
+  else
+    let first = "size", List.map fst (snd (List.hd rs)) in
+    let col_width = 11 in
+    let space ?(extra = 0) s = String.make (col_width - String.length s - extra) ' ' in
+    print_endline "";
+    print_endline "------------";
+    print_endline ("| " ^ alg ^ space ~extra:3 alg ^ " |");
+    print_endline "------------";
+    (let extra = 5 in
+     if String.length (fst first) > col_width - extra then
+       Printf.printf "%s " (String.sub (fst first) 0 (col_width - extra - 1))
+     else
+       Printf.printf "%s%s" (fst first) (space ~extra (fst first)));
+    let rpad s =
+      if String.length s > col_width - 1 then
+        Printf.printf "%s " (String.sub s 0 (col_width - 1))
+      else
+        Printf.printf "%s%s " (space ~extra:1 s) s
+    in
+    List.iter rpad (List.map fst rs);
+    Printf.printf "\n";
+    List.iter (fun size ->
+        Printf.printf "%5d " size;
+        let vals =
+          List.map (fun data ->
+              Option.value ~default:0.0 (List.assoc_opt size data) /. mb)
+            (List.map snd rs)
+        in
+        let max_bw = List.fold_left Float.max 0.0 vals in
+        List.iter (fun v ->
+            let st = if Float.equal max_bw v then "*" else " " in
+            Printf.printf " %s%8.3f%s" st v st)
+          vals;
+        Printf.printf "\n";
+      ) (snd first);
+    Printf.printf "First column in bytes, all others in MB/s (1MB = 1024 * 1024)\n\n%!"
+
+let openssl_speed args =
+  let cmd = Bos.Cmd.(v "openssl" % "speed" % "-mr" %% of_list args) in
+  print_endline ("  benchmarking " ^ Bos.Cmd.to_string cmd);
+  match Bos.(OS.Cmd.(run_out ~err:err_null cmd |> out_lines |> success)) with
+  | Error `Msg m -> invalid_arg m
+  | Ok lines ->
+    (* we're looking for +H:N0:N1:N2... and subsequent +F:?:?arg:V1:V2:V3 *)
+    let sizes, bw =
+      List.fold_left (fun acc line ->
+          match acc with
+          | None, None when String.(equal (sub line 0 3) "+H:") ->
+            Some (List.map int_of_string (List.tl (String.split_on_char ':' line))), None
+          | Some _ as s, None when String.(equal (sub line 0 3) "+F:") ->
+            (match String.split_on_char ':' line with
+             | _f :: _ :: algo :: rest -> s, Some (algo, List.map float_of_string rest)
+             | _ -> invalid_arg ("unexpected line starting with +F: " ^ line))
+          | _ -> acc)
+        (None, None) lines
+    in
+    let s = Option.get sizes
+    and _alg, bw = Option.get bw
+    in
+    "openssl", List.combine s bw
+
+let bench name f a =
+  print_endline ("  benchmarking " ^ name ^ "...");
+  name, List.map (fun (s, v, _, _) -> (s, v)) (f a)
+
+let benchmarks = [
+  ("md5", fun () ->
+      print_endline "MD5";
+      let nc = bench "nocrypto" through_cs Nocrypto.Hash.MD5.digest in
+      let mc = bench "mirage-crypto" through_cs Mirage_crypto.Hash.MD5.digest in
+      let di = bench "digestif" through_str Digestif.MD5.digest_string in
+      let std = bench "stdlib" through_str Digest.string in
+      let ck = bench "cryptokit" through_str Cryptokit.(hash_string (Hash.md5 ())) in
+      let os = openssl_speed [ "md5" ] in
+      let rs = [ nc ; mc ; di ; std ; ck ; os ]
+      in
+      print_result_table "MD5" rs;
+  );
+
+  ("sha1", fun () ->
+      print_endline "SHA1";
+      let nc = bench "nocrypto" through_cs Nocrypto.Hash.SHA1.digest in
+      let mc = bench "mirage-crypto" through_cs Mirage_crypto.Hash.SHA1.digest in
+      let di = bench "digestif" through_str Digestif.SHA1.digest_string in
+      let std = bench "ocaml-sha" through_str Sha1.string in
+      let ck = bench "cryptokit" through_str Cryptokit.(hash_string (Hash.sha1 ())) in
+      let os = openssl_speed [ "sha1" ] in
+      let rs = [ nc ; mc ; di ; std ; ck ; os ] in
+      print_result_table "SHA1" rs;
+  ) ;
+
+  ("sha256", fun () ->
+      print_endline "SHA256";
+      let nc = bench "nocrypto" through_cs Nocrypto.Hash.SHA256.digest in
+      let mc = bench "mirage-crypto" through_cs Mirage_crypto.Hash.SHA256.digest in
+      let di = bench "digestif" through_str Digestif.SHA256.digest_string in
+      let std = bench "ocaml-sha" through_str Sha256.string in
+      let ck = bench "cryptokit" through_str Cryptokit.(hash_string (Hash.sha256 ())) in
+      let os = openssl_speed [ "sha256" ] in
+      let rs = [ nc ; mc ; di ; std ; ck ; os ] in
+      print_result_table "SHA256" rs;
+  ) ;
+
+  ("sha512", fun () ->
+      print_endline "SHA512";
+      let nc = bench "nocrypto" through_cs Nocrypto.Hash.SHA512.digest in
+      let mc = bench "mirage-crypto" through_cs Mirage_crypto.Hash.SHA512.digest in
+      let di = bench "digestif" through_str Digestif.SHA512.digest_string in
+      let std = bench "ocaml-sha" through_str Sha512.string in
+      let ck = bench "cryptokit" through_str Cryptokit.(hash_string (Hash.sha512 ())) in
+      let os = openssl_speed [ "sha512" ] in
+      let rs = [ nc ; mc ; di ; std ; ck ; os ] in
+      print_result_table "SHA512" rs;
+  ) ;
+]
+
+let help () =
+  Printf.printf "available benchmarks:\n  ";
+  List.iter (fun (n, _) -> Printf.printf "%s  " n) benchmarks ;
+  Printf.printf "\n%!"
+
+let runv fs =
+  Time.warmup () ;
+  List.iter (fun f -> f ()) fs
+
+let () =
+  let seed = Cstruct.of_string "abcd" in
+  let g = Mirage_crypto_rng.(create ~seed (module Fortuna)) in
+  Mirage_crypto_rng.set_default_generator g;
+  match Array.to_list Sys.argv with
+  | _::(_::_ as args) -> begin
+      try
+        let fs =
+          args |> List.map @@ fun n ->
+            snd (benchmarks |> List.find @@ fun (n1, _) -> n = n1) in
+        runv fs
+      with Not_found -> help ()
+    end
+  | _ -> help ()

--- a/bench/digests.ml
+++ b/bench/digests.ml
@@ -5,27 +5,28 @@ let print_result_table alg rs =
     print_endline "rs is empty"
   else
     let first = "size", List.map fst (snd (List.hd rs)) in
-    let col_width = 11 in
+    let col_width = 12 in
     let space ?(extra = 0) s = String.make (col_width - String.length s - extra) ' ' in
     print_endline "";
-    print_endline "------------";
-    print_endline ("| " ^ alg ^ space ~extra:3 alg ^ " |");
-    print_endline "------------";
-    (let extra = 5 in
+    print_endline ("## " ^ alg);
+    print_endline "";
+    (let extra = 6 in
      if String.length (fst first) > col_width - extra then
-       Printf.printf "%s " (String.sub (fst first) 0 (col_width - extra - 1))
+       Printf.printf "| %s " (String.sub (fst first) 0 (col_width - extra - 1))
      else
-       Printf.printf "%s%s" (fst first) (space ~extra (fst first)));
+       Printf.printf "| %s%s" (fst first) (space ~extra (fst first)));
     let rpad s =
-      if String.length s > col_width - 1 then
-        Printf.printf "%s " (String.sub s 0 (col_width - 1))
+      if String.length s > col_width - 2 then
+        Printf.printf "| %s " (String.sub s 0 (col_width - 2))
       else
-        Printf.printf "%s%s " (space ~extra:1 s) s
+        Printf.printf "| %s%s " (space ~extra:2 s) s
     in
     List.iter rpad (List.map fst rs);
-    Printf.printf "\n";
+    Printf.printf "|\n";
+    Printf.printf "|-------|%s\n"
+      (String.concat "" (List.map (fun _ -> String.make col_width '-' ^ "|") rs));
     List.iter (fun size ->
-        Printf.printf "%5d " size;
+        Printf.printf "| %5d " size;
         let vals =
           List.map (fun data ->
               Option.value ~default:0.0 (List.assoc_opt size data) /. mb)
@@ -34,11 +35,11 @@ let print_result_table alg rs =
         let max_bw = List.fold_left Float.max 0.0 vals in
         List.iter (fun v ->
             let st = if Float.equal max_bw v then "*" else " " in
-            Printf.printf " %s%8.3f%s" st v st)
+            Printf.printf "| %s%8.3f%s " st v st)
           vals;
-        Printf.printf "\n";
+        Printf.printf "|\n";
       ) (snd first);
-    Printf.printf "First column in bytes, all others in MB/s (1MB = 1024 * 1024)\n\n%!"
+    Printf.printf "\nFirst column in bytes, all others in MB/s (1MB = 1024 * 1024)\n%!"
 
 let openssl_speed args =
   let cmd = Bos.Cmd.(v "openssl" % "speed" % "-mr" %% of_list args) in
@@ -77,8 +78,7 @@ let benchmarks = [
       let std = bench "stdlib" through_str Digest.string in
       let ck = bench "cryptokit" through_str Cryptokit.(hash_string (Hash.md5 ())) in
       let os = openssl_speed [ "md5" ] in
-      let rs = [ nc ; mc ; di ; std ; ck ; os ]
-      in
+      let rs = [ nc ; mc ; di ; std ; ck ; os ] in
       print_result_table "MD5" rs;
   );
 

--- a/bench/digests.ml
+++ b/bench/digests.ml
@@ -1,46 +1,5 @@
 open Helper
 
-let print_result_table alg rs =
-  if rs = [] then
-    print_endline "rs is empty"
-  else
-    let first = "size", List.map fst (snd (List.hd rs)) in
-    let col_width = 12 in
-    let space ?(extra = 0) s = String.make (col_width - String.length s - extra) ' ' in
-    print_endline "";
-    print_endline ("## " ^ alg);
-    print_endline "";
-    (let extra = 6 in
-     if String.length (fst first) > col_width - extra then
-       Printf.printf "| %s " (String.sub (fst first) 0 (col_width - extra - 1))
-     else
-       Printf.printf "| %s%s" (fst first) (space ~extra (fst first)));
-    let rpad s =
-      if String.length s > col_width - 2 then
-        Printf.printf "| %s " (String.sub s 0 (col_width - 2))
-      else
-        Printf.printf "| %s%s " (space ~extra:2 s) s
-    in
-    List.iter rpad (List.map fst rs);
-    Printf.printf "|\n";
-    Printf.printf "|-------|%s\n"
-      (String.concat "" (List.map (fun _ -> String.make col_width '-' ^ "|") rs));
-    List.iter (fun size ->
-        Printf.printf "| %5d " size;
-        let vals =
-          List.map (fun data ->
-              Option.value ~default:0.0 (List.assoc_opt size data) /. mb)
-            (List.map snd rs)
-        in
-        let max_bw = List.fold_left Float.max 0.0 vals in
-        List.iter (fun v ->
-            let st = if Float.equal max_bw v then "*" else " " in
-            Printf.printf "| %s%8.3f%s " st v st)
-          vals;
-        Printf.printf "|\n";
-      ) (snd first);
-    Printf.printf "\nFirst column in bytes, all others in MB/s (1MB = 1024 * 1024)\n%!"
-
 let openssl_speed args =
   let cmd = Bos.Cmd.(v "openssl" % "speed" % "-mr" %% of_list args) in
   print_endline ("  benchmarking " ^ Bos.Cmd.to_string cmd);
@@ -63,11 +22,11 @@ let openssl_speed args =
     let s = Option.get sizes
     and _alg, bw = Option.get bw
     in
-    "openssl", List.combine s bw
+    "openssl", List.combine s (List.map (fun bw -> bw /. mb) bw)
 
 let bench name f a =
   print_endline ("  benchmarking " ^ name ^ "...");
-  name, List.map (fun (s, v, _, _) -> (s, v)) (f a)
+  name, List.map (fun (s, v, _, _) -> (s, v /. mb)) (f a)
 
 let benchmarks = [
   ("md5", fun () ->

--- a/bench/dune
+++ b/bench/dune
@@ -15,3 +15,9 @@
  (modules digests)
  (libraries helper mirage-crypto mirage-crypto-rng nocrypto digestif sha cryptokit bos)
  (optional))
+
+(executables
+ (names ec)
+ (modules ec)
+ (libraries helper mirage-crypto mirage-crypto-rng mirage-crypto-ec callipyge rfc7748 hacl_x25519 bos)
+ (optional))

--- a/bench/dune
+++ b/bench/dune
@@ -1,5 +1,17 @@
+(library
+ (name helper)
+ (wrapped false)
+ (modules helper)
+ (libraries cstruct mirage-crypto-rng))
+
 (executables
  (names speed)
  (modules speed)
- (libraries mirage-crypto mirage-crypto-rng mirage-crypto-rng.unix
+ (libraries helper mirage-crypto mirage-crypto-rng mirage-crypto-rng.unix
    mirage-crypto-pk mirage-crypto-ec))
+
+(executables
+ (names digests)
+ (modules digests)
+ (libraries helper mirage-crypto mirage-crypto-rng nocrypto digestif sha cryptokit bos)
+ (optional))

--- a/bench/ec.ml
+++ b/bench/ec.ml
@@ -1,0 +1,111 @@
+
+open Helper
+
+let secret_hex = "4c6db7cf935bcf84026178d40c956af09d8e363203490d2c41625acb68b931a4"
+let secret_cs = Cstruct.of_hex secret_hex
+let secret_str = Cstruct.to_string secret_cs
+
+let share_hex = "ca19193cf5c0b38c61aa01c172b2e93d16f750d0846277ad322de5e4fb332429"
+let share_cs = Cstruct.of_hex share_hex
+let share_str = Cstruct.to_string share_cs
+
+let res_hex = "075137d4b326c438c9634ecaffb8f7f60b51f3a6fe2bcb5a3b21db1101f70b07"
+let res_cs = Cstruct.of_hex res_hex
+let res_str = Cstruct.to_string res_cs
+
+let ecdh_shares = [
+  ("mirage-crypto", `Mirage_crypto (Mirage_crypto_ec.X25519.secret_of_cs secret_cs |> Result.get_ok |> fst, share_cs));
+  ("callipyge", `Callipyge Callipyge.(secret_key_of_string secret_str, public_key_of_string share_str));
+  ("rfc7748", `Rfc7748 Rfc7748.X25519.(private_key_of_string secret_hex, public_key_of_string share_hex));
+  ("hacl_x25519", `Hacl_x25519 Hacl_x25519.(gen_key ~rng:(fun _ -> secret_cs) |> fst, share_cs));
+  ("openssl", `Openssl)
+]
+
+let bm name f = (name, fun () -> f name)
+
+let openssl_speed args =
+  let cmd = Bos.Cmd.(v "openssl" % "speed" % "-mr" %% of_list args) in
+  print_endline ("  benchmarking " ^ Bos.Cmd.to_string cmd);
+  match Bos.(OS.Cmd.(run_out ~err:err_null cmd |> out_lines |> success)) with
+  | Error `Msg m -> invalid_arg m
+  | Ok lines ->
+    (* we're looking for +F?:?:?arg:V:? *)
+    let ops =
+      List.fold_left (fun acc line ->
+          match acc with
+          | None when String.(equal (sub line 0 2) "+F") ->
+            (match String.split_on_char ':' line with
+             | _f :: _ :: _algo :: v :: _rest ->
+               Some (float_of_string v)
+             | _ -> invalid_arg ("unexpected line starting with +F: " ^ line))
+          | _ -> acc)
+        None lines
+    in
+    "openssl", [ 1, Option.get ops ]
+
+let c name f n =
+  print_endline ("  benchmarking " ^ name ^ "...");
+  Gc.full_major () ;
+  let iters, time = count_it f n in
+  name, [ 1, float iters /. time ]
+
+let benchmarks = [
+  ("ecdh-share", fun () ->
+      print_endline "ecdh-share";
+      let res =
+        List.map (fun (name, x) -> match x with
+            | `Mirage_crypto (sec, share) ->
+              c name (fun share ->
+                  let out = Mirage_crypto_ec.X25519.key_exchange sec share |> Result.get_ok in
+                  ignore out;
+                  (* assert (Cstruct.equal out res_cs) *))
+                share
+            | `Callipyge (secret, public) ->
+              c name (fun public ->
+                  let out = Callipyge.shared ~secret ~public in
+                  ignore out;
+                  (* assert (String.equal (Callipyge.string_of_key out) res_str) *))
+                public
+            | `Rfc7748 (sec, share) ->
+              c name (fun share ->
+                  let out = Rfc7748.X25519.scale sec share in
+                  ignore out;
+                  (* assert (String.equal (Rfc7748.X25519.string_of_public_key out) res_hex) *))
+                share
+            | `Hacl_x25519 (sec, share) ->
+              c name (fun share ->
+                  let out = Hacl_x25519.key_exchange sec share |> Result.get_ok in
+                  ignore out;
+                  (* assert (Cstruct.equal out res_cs) *))
+                share
+             | `Openssl -> openssl_speed [ "ecdhx25519" ])
+          ecdh_shares
+      in
+      let footer = "All numbers in operations per second" in
+      print_result_table ~first:"" ~footer "X25519" res)
+
+]
+
+let help () =
+  Printf.printf "available benchmarks:\n  ";
+  List.iter (fun (n, _) -> Printf.printf "%s  " n) benchmarks ;
+  Printf.printf "\n%!"
+
+let runv fs =
+  Time.warmup () ;
+  List.iter (fun f -> f ()) fs
+
+let () =
+  let seed = Cstruct.of_string "abcd" in
+  let g = Mirage_crypto_rng.(create ~seed (module Fortuna)) in
+  Mirage_crypto_rng.set_default_generator g;
+  match Array.to_list Sys.argv with
+  | _::(_::_ as args) -> begin
+      try
+        let fs =
+          args |> List.map @@ fun n ->
+            snd (benchmarks |> List.find @@ fun (n1, _) -> n = n1) in
+        runv fs
+      with Not_found -> help ()
+    end
+  | _ -> help ()

--- a/bench/helper.ml
+++ b/bench/helper.ml
@@ -1,0 +1,82 @@
+module Time = struct
+
+  let time ~n f a =
+    let t1 = Sys.time () in
+    for _ = 1 to n do ignore (f a) done ;
+    let t2 = Sys.time () in
+    (t2 -. t1)
+
+  let warmup () =
+    let x = ref 0 in
+    let rec go start =
+      if Sys.time () -. start < 1. then begin
+        for i = 0 to 10000 do x := !x + i done ;
+        go start
+      end in
+    go (Sys.time ())
+
+end
+
+let burn_period = 3.0
+
+let sizes = [16; 64; 256; 1024; 8192]
+(* let sizes = [16] *)
+
+let burn f data n =
+  let (t1, i1) =
+    let rec loop it =
+      let t = Time.time ~n:it f data in
+      if t > 0.2 then (t, it) else loop (it * 10) in
+    loop 10 in
+  let iters = int_of_float (float i1 *. burn_period /. t1) in
+  let time  = Time.time ~n:iters f data in
+  (iters, time, float (n * iters) /. time)
+
+let mb = 1024. *. 1024.
+
+let through f gen =
+  sizes |> List.map @@ fun size ->
+    Gc.full_major () ;
+    let data = gen size in
+    let (iters, time, bw) = burn f data size in
+    size, bw, iters, time
+
+let through_str f =
+  through f (fun s -> Cstruct.to_string (Mirage_crypto_rng.generate s))
+
+let through_cs f =
+  through f Mirage_crypto_rng.generate
+
+let print_hdr title =
+  Printf.printf "\n* [%s]\n%!" title
+
+let print_result =
+  List.iter (fun (size, bw, iters, time) ->
+      Printf.printf "    % 5d:  %04f MB/s  (%d iters in %.03f s)\n%!"
+        size (bw /. mb) iters time)
+
+let throughput_str title f =
+  print_hdr title;
+  print_result (through_str f)
+
+let throughput title f =
+  print_hdr title;
+  print_result (through_cs f)
+
+let count_period = 10.
+
+let count f n =
+  ignore (f n);
+  let i1 = 5 in
+  let t1 = Time.time ~n:i1 f n in
+  let iters = int_of_float (float i1 *. count_period /. t1) in
+  let time  = Time.time ~n:iters f n in
+  (iters, time)
+
+let count title f to_str args =
+  Printf.printf "\n* [%s]\n%!" title ;
+  args |> List.iter @@ fun arg ->
+  Gc.full_major () ;
+  let iters, time = count f arg in
+  Printf.printf "    %s:  %.03f ops per second (%d iters in %.03f)\n%!"
+    (to_str arg) (float iters /. time) iters time


### PR DESCRIPTION
I wanted to easily compare different implementations, and started with hashing / digests.

In this PR, first the `bench/speed.exe` has a split-off helper.ml (no surprises) ;)

Then, I developed `bench/digests.exe` which tests nocrypto (https://github.com/hannesm/ocaml-nocrypto/tree/compiles - 0.5.4-2 plus allowing newer cstruct releases to avoid lots of changes in my switch), mirage-crypto (commit 6fa26bd2e501e2c7d4b61e7afd5297d4197a622d), digestif 1.1.4, ocaml-sha 1.15.4, cryptokit 1.19, OCaml 4.14.1 and openssl 3.0.12

All tests are run on my i7-5600U CPU @ 2.60GHz using FreeBSD-14, OCaml 4.14.1 (happy to see numbers on other architectures / processors):

Resuls:
## MD5

| size  |   nocrypto | mirage-cry |   digestif |     stdlib |  cryptokit |    openssl |
|-------|------------|------------|------------|------------|------------|------------|
|    16 |    51.682  |    63.650  |    78.144  | * 107.970* |    90.273  |    59.678  |
|    64 |   148.387  |   172.181  |   195.855  | * 230.107* |   205.056  |   169.489  |
|   256 |   313.978  |   332.245  |   357.565  | * 385.844* |   361.911  |   364.497  |
|  1024 |   433.760  |   445.244  |   455.512  |   464.499  |   454.579  | * 513.199* |
|  8192 |   486.566  |   489.529  |   491.404  |   492.987  |   490.263  | * 587.799* |

First column in bytes, all others in MB/s (1MB = 1024 * 1024)

## SHA1

| size  |   nocrypto | mirage-cry |   digestif |  ocaml-sha |  cryptokit |    openssl |
|-------|------------|------------|------------|------------|------------|------------|
|    16 |    43.659  |    54.273  |    65.635  | *  74.074* |    52.385  |    56.167  |
|    64 |   122.322  |   142.711  |   161.865  | * 176.676* |   116.828  |   164.608  |
|   256 |   260.846  |   279.374  |   298.677  |   315.168  |   199.342  | * 398.186* |
|  1024 |   364.759  |   375.541  |   385.924  |   393.510  |   245.253  | * 614.528* |
|  8192 |   416.407  |   415.313  |   420.857  |   430.265  |   261.766  | * 736.483* |

First column in bytes, all others in MB/s (1MB = 1024 * 1024)

## SHA256

| size  |   nocrypto | mirage-cry |   digestif |  ocaml-sha |  cryptokit |    openssl |
|-------|------------|------------|------------|------------|------------|------------|
|    16 |    26.480  |    31.774  |    34.243  |    36.839  |    34.678  | *  38.340* |
|    64 |    69.416  |    77.409  |    82.467  |    81.558  |    76.503  | *  99.244* |
|   256 |   131.065  |   139.294  |   142.987  |   137.850  |   129.533  | * 219.244* |
|  1024 |   171.909  |   173.974  |   175.883  |   163.997  |   157.563  | * 305.108* |
|  8192 |   188.027  |   188.982  |   188.704  |   180.706  |   168.621  | * 341.120* |

First column in bytes, all others in MB/s (1MB = 1024 * 1024)

## SHA512

| size  |   nocrypto | mirage-cry |   digestif |  ocaml-sha |  cryptokit |    openssl |
|-------|------------|------------|------------|------------|------------|------------|
|    16 |    23.323  |    25.765  |    25.326  |    23.991  |    25.605  | *  30.038* |
|    64 |    92.719  |   103.203  |    99.902  |   104.559  |   110.152  | * 120.589* |
|   256 |   165.876  |   167.433  |   158.540  |   156.484  |   167.372  | * 244.509* |
|  1024 |   243.956  |   237.645  |   235.108  |   230.279  |   234.339  | * 387.885* |
|  8192 |   282.661  |   269.457  |   270.386  |   253.435  |   266.440  | * 487.495* |

First column in bytes, all others in MB/s (1MB = 1024 * 1024)
