### PR TITLE
RNG: fix some docstrings

### DIFF
--- a/mirage/config.ml
+++ b/mirage/config.ml
@@ -8,6 +8,7 @@ let () =
     package "mirage-crypto-pk" ;
     package "mirage-crypto" ;
     package ~min:"0.8.7" "fmt" ;
+    package "ohex" ;
   ]
   in
   register ~packages "crypto-test" [main $ default_random]

--- a/mirage/unikernel.ml
+++ b/mirage/unikernel.ml
@@ -3,14 +3,14 @@ module Main (R : Mirage_random.S) = struct
     Logs.info (fun m -> m "using Fortuna, entropy sources: %a"
                   Fmt.(list ~sep:(any ", ") Mirage_crypto_rng.Entropy.pp_source)
                   (Mirage_crypto_rng.Entropy.sources ())) ;
-    Logs.info (fun m -> m "64 byte random:@ %a" Cstruct.hexdump_pp
+    Logs.info (fun m -> m "64 byte random:@ %a" (Ohex.pp_hexdump ())
                   (R.generate 64)) ;
-    let n = Cstruct.create 32 in
+    let n = Bytes.(unsafe_to_string (create 32)) in
     let key = Mirage_crypto.Chacha20.of_secret n
-    and nonce = Cstruct.create 12
+    and nonce = Bytes.(unsafe_to_string (create 12))
     in
     Logs.info (fun m -> m "Chacha20/Poly1305 of 32*0, key 32*0, nonce 12*0: %a"
-                  Cstruct.hexdump_pp
+                  (Ohex.pp_hexdump ())
                   (Mirage_crypto.Chacha20.authenticate_encrypt ~key ~nonce n));
     let key = Mirage_crypto_pk.Rsa.generate ~bits:4096 () in
     let signature =

--- a/rng/mirage_crypto_rng.mli
+++ b/rng/mirage_crypto_rng.mli
@@ -231,11 +231,13 @@ val unset_default_generator : unit -> unit
 (**/**)
 
 val generate_into : ?g:g -> bytes -> ?off:int -> int -> unit
-(** Invoke {{!Generator.generate}generate} on [g] or
-    {{!generator}default generator}. The offset [off] defaults to 0. *)
+(** [generate_into ~g buf ~off len] invokes
+    {{!Generator.generate_into}generate_into} on [g] or
+    {{!generator}default generator}. The random data is put into [buf] starting
+    at [off] (defaults to 0) with [len] bytes. *)
 
 val generate : ?g:g -> int -> string
-(** Invoke {generate_into} on [g] or {{!generator}default generator} and a
+(** Invoke {!generate_into} on [g] or {{!generator}default generator} and a
     freshly allocated string. *)
 
 val block : g option -> int


### PR DESCRIPTION
mirage unikernel: update to avoid cstruct

this requires the new mirage-random interface -- https://github.com/mirage/mirage-random/pull/15 -- together with a mirage release that allows such an API change (I'll figure out a roadmap how to incrementally adapt mirage with no-cstruct).