### PR TITLE
Set a new bytes used for elliptic curves computations to '\000'

### DIFF
--- a/ec/mirage_crypto_ec.ml
+++ b/ec/mirage_crypto_ec.ml
@@ -135,7 +135,7 @@ end
 module Make_field_element (P : Parameters) (F : Foreign) : Field_element = struct
   let b_uts b = Bytes.unsafe_to_string b
 
-  let create () = Bytes.make P.fe_length '\000'
+  let create () = Bytes.create P.fe_length
 
   let mul a b =
     let tmp = create () in
@@ -158,7 +158,8 @@ module Make_field_element (P : Parameters) (F : Foreign) : Field_element = struc
     b_uts tmp
 
   let zero =
-    b_uts (create ())
+    let b = Bytes.make P.fe_length '\000' in
+    b_uts b
 
   let one =
     let fe = create () in

--- a/ec/mirage_crypto_ec.ml
+++ b/ec/mirage_crypto_ec.ml
@@ -135,7 +135,7 @@ end
 module Make_field_element (P : Parameters) (F : Foreign) : Field_element = struct
   let b_uts b = Bytes.unsafe_to_string b
 
-  let create () = Bytes.create P.fe_length
+  let create () = Bytes.make P.fe_length '\000'
 
   let mul a b =
     let tmp = create () in


### PR DESCRIPTION
`Cstruct.create` does this. If we don't initialize bytes with '\000', `Field_element.zero` can be something else than '\000'. It's a fix for mirleft/ocaml-x509#167.