### PR TITLE
provide ciphers with {de,en}crypt_into functionality

### DIFF
--- a/bench/speed.ml
+++ b/bench/speed.ml
@@ -372,6 +372,22 @@ let benchmarks = [
     throughput_into name
       (fun dst cs -> AES.ECB.encrypt_into ~key cs ~src_off:0 dst ~dst_off:0 (String.length cs))) ;
 
+  bm "aes-192-ecb" (fun name ->
+    let key = AES.ECB.of_secret (Mirage_crypto_rng.generate 24) in
+    throughput_into name (fun dst cs -> AES.ECB.encrypt_into ~key cs ~src_off:0 dst ~dst_off:0 (String.length cs))) ;
+
+  bm "aes-192-ecb-unsafe" (fun name ->
+    let key = AES.ECB.of_secret (Mirage_crypto_rng.generate 24) in
+    throughput_into name (fun dst cs -> AES.ECB.unsafe_encrypt_into ~key cs ~src_off:0 dst ~dst_off:0 (String.length cs))) ;
+
+  bm "aes-256-ecb" (fun name ->
+    let key = AES.ECB.of_secret (Mirage_crypto_rng.generate 32) in
+    throughput_into name (fun dst cs -> AES.ECB.encrypt_into ~key cs ~src_off:0 dst ~dst_off:0 (String.length cs))) ;
+
+  bm "aes-256-ecb-unsafe" (fun name ->
+    let key = AES.ECB.of_secret (Mirage_crypto_rng.generate 32) in
+    throughput_into name (fun dst cs -> AES.ECB.unsafe_encrypt_into ~key cs ~src_off:0 dst ~dst_off:0 (String.length cs))) ;
+
   bm "aes-128-ecb-unsafe" (fun name ->
     let key = AES.ECB.of_secret (Mirage_crypto_rng.generate 16) in
     throughput_into name
@@ -423,35 +439,45 @@ let benchmarks = [
     let key = AES.GCM.of_secret (Mirage_crypto_rng.generate 16)
     and nonce = Mirage_crypto_rng.generate 12 in
     throughput_into ~add:AES.GCM.tag_size name
-      (fun dst cs -> AES.GCM.authenticate_encrypt_into ~key ~nonce cs ~src_off:0 dst ~dst_off:0 ~tag_off:(String.length cs - AES.GCM.tag_size) (String.length cs)));
+      (fun dst cs -> AES.GCM.authenticate_encrypt_into ~key ~nonce cs ~src_off:0 dst ~dst_off:0 ~tag_off:(String.length cs) (String.length cs)));
 
   bm "aes-128-gcm-unsafe" (fun name ->
     let key = AES.GCM.of_secret (Mirage_crypto_rng.generate 16)
     and nonce = Mirage_crypto_rng.generate 12 in
     throughput_into ~add:AES.GCM.tag_size name
-      (fun dst cs -> AES.GCM.unsafe_authenticate_encrypt_into ~key ~nonce cs ~src_off:0 dst ~dst_off:0 ~tag_off:(String.length cs - AES.GCM.tag_size) (String.length cs)));
+      (fun dst cs -> AES.GCM.unsafe_authenticate_encrypt_into ~key ~nonce cs ~src_off:0 dst ~dst_off:0 ~tag_off:(String.length cs) (String.length cs)));
 
   bm "aes-128-ghash" (fun name ->
     let key = AES.GCM.of_secret (Mirage_crypto_rng.generate 16)
     and nonce = Mirage_crypto_rng.generate 12 in
-    throughput name (fun cs -> AES.GCM.authenticate_encrypt ~key ~nonce ~adata:cs ""));
+    throughput_into ~add:AES.GCM.tag_size name
+      (fun dst cs -> AES.GCM.authenticate_encrypt_into ~key ~nonce ~adata:cs "" ~src_off:0 dst ~dst_off:0 ~tag_off:0 0));
+
+  bm "aes-128-ghash-unsafe" (fun name ->
+    let key = AES.GCM.of_secret (Mirage_crypto_rng.generate 16)
+    and nonce = Mirage_crypto_rng.generate 12 in
+    throughput_into ~add:AES.GCM.tag_size name
+      (fun dst cs -> AES.GCM.unsafe_authenticate_encrypt_into ~key ~nonce ~adata:cs "" ~src_off:0 dst ~dst_off:0 ~tag_off:0 0));
 
   bm "aes-128-ccm" (fun name ->
     let key   = AES.CCM16.of_secret (Mirage_crypto_rng.generate 16)
     and nonce = Mirage_crypto_rng.generate 10 in
-    throughput name (fun cs -> AES.CCM16.authenticate_encrypt ~key ~nonce cs));
+    throughput_into ~add:AES.CCM16.tag_size name
+      (fun dst cs -> AES.CCM16.authenticate_encrypt_into ~key ~nonce cs ~src_off:0 dst ~dst_off:0 ~tag_off:(String.length cs) (String.length cs)));
 
-  bm "aes-192-ecb" (fun name ->
-    let key = AES.ECB.of_secret (Mirage_crypto_rng.generate 24) in
-    throughput name (fun cs -> AES.ECB.encrypt ~key cs)) ;
-
-  bm "aes-256-ecb" (fun name ->
-    let key = AES.ECB.of_secret (Mirage_crypto_rng.generate 32) in
-    throughput name (fun cs -> AES.ECB.encrypt ~key cs)) ;
+  bm "aes-128-ccm-unsafe" (fun name ->
+    let key   = AES.CCM16.of_secret (Mirage_crypto_rng.generate 16)
+    and nonce = Mirage_crypto_rng.generate 10 in
+    throughput_into ~add:AES.CCM16.tag_size name
+      (fun dst cs -> AES.CCM16.unsafe_authenticate_encrypt_into ~key ~nonce cs ~src_off:0 dst ~dst_off:0 ~tag_off:(String.length cs) (String.length cs)));
 
   bm "d3des-ecb" (fun name ->
     let key = DES.ECB.of_secret (Mirage_crypto_rng.generate 24) in
-    throughput name (fun cs -> DES.ECB.encrypt ~key cs)) ;
+    throughput_into name (fun dst cs -> DES.ECB.encrypt_into ~key cs ~src_off:0 dst ~dst_off:0 (String.length cs))) ;
+
+  bm "d3des-ecb-unsafe" (fun name ->
+    let key = DES.ECB.of_secret (Mirage_crypto_rng.generate 24) in
+    throughput_into name (fun dst cs -> DES.ECB.unsafe_encrypt_into ~key cs ~src_off:0 dst ~dst_off:0 (String.length cs))) ;
 
   bm "fortuna" (fun name ->
     let open Mirage_crypto_rng.Fortuna in

--- a/bench/speed.ml
+++ b/bench/speed.ml
@@ -405,7 +405,12 @@ let benchmarks = [
   bm "aes-128-ctr" (fun name ->
     let key = Mirage_crypto_rng.generate 16 |> AES.CTR.of_secret
     and ctr = Mirage_crypto_rng.generate 16 |> AES.CTR.ctr_of_octets in
-    throughput name (fun cs -> AES.CTR.encrypt ~key ~ctr cs)) ;
+    throughput_into name (fun dst cs -> AES.CTR.encrypt_into ~key ~ctr cs ~src_off:0 dst ~dst_off:0 (String.length cs))) ;
+
+  bm "aes-128-ctr-unsafe" (fun name ->
+    let key = Mirage_crypto_rng.generate 16 |> AES.CTR.of_secret
+    and ctr = Mirage_crypto_rng.generate 16 |> AES.CTR.ctr_of_octets in
+    throughput_into name (fun dst cs -> AES.CTR.unsafe_encrypt_into ~key ~ctr cs ~src_off:0 dst ~dst_off:0 (String.length cs))) ;
 
   bm "aes-128-gcm" (fun name ->
     let key = AES.GCM.of_secret (Mirage_crypto_rng.generate 16)

--- a/bench/speed.ml
+++ b/bench/speed.ml
@@ -373,12 +373,34 @@ let benchmarks = [
   bm "aes-128-cbc-e" (fun name ->
     let key = AES.CBC.of_secret (Mirage_crypto_rng.generate 16)
     and iv  = Mirage_crypto_rng.generate 16 in
-    throughput name (fun cs -> AES.CBC.encrypt ~key ~iv cs)) ;
+    throughput_into name
+      (fun dst cs -> AES.CBC.encrypt_into ~key ~iv cs ~src_off:0 dst ~dst_off:0 (String.length cs))) ;
+
+  bm "aes-128-cbc-e-unsafe" (fun name ->
+    let key = AES.CBC.of_secret (Mirage_crypto_rng.generate 16)
+    and iv  = Mirage_crypto_rng.generate 16 in
+    throughput_into name
+      (fun dst cs -> AES.CBC.unsafe_encrypt_into ~key ~iv cs ~src_off:0 dst ~dst_off:0 (String.length cs))) ;
+
+  bm "aes-128-cbc-e-unsafe-inplace" (fun name ->
+    let key = AES.CBC.of_secret (Mirage_crypto_rng.generate 16)
+    and iv  = Mirage_crypto_rng.generate 16 in
+    throughput name
+      (fun cs ->
+         let b = Bytes.unsafe_of_string cs in
+         AES.CBC.unsafe_encrypt_into_inplace ~key ~iv b ~dst_off:0 (String.length cs))) ;
 
   bm "aes-128-cbc-d" (fun name ->
     let key = AES.CBC.of_secret (Mirage_crypto_rng.generate 16)
     and iv  = Mirage_crypto_rng.generate 16 in
-    throughput name (fun cs -> AES.CBC.decrypt ~key ~iv cs)) ;
+    throughput_into name
+      (fun dst cs -> AES.CBC.decrypt_into ~key ~iv cs ~src_off:0 dst ~dst_off:0 (String.length cs))) ;
+
+  bm "aes-128-cbc-d-unsafe" (fun name ->
+    let key = AES.CBC.of_secret (Mirage_crypto_rng.generate 16)
+    and iv  = Mirage_crypto_rng.generate 16 in
+    throughput_into name
+      (fun dst cs -> AES.CBC.unsafe_decrypt_into ~key ~iv cs ~src_off:0 dst ~dst_off:0 (String.length cs))) ;
 
   bm "aes-128-ctr" (fun name ->
     let key = Mirage_crypto_rng.generate 16 |> AES.CTR.of_secret

--- a/src/aead.ml
+++ b/src/aead.ml
@@ -10,4 +10,16 @@ module type AEAD = sig
     string -> string * string
   val authenticate_decrypt_tag : key:key -> nonce:string -> ?adata:string ->
     tag:string -> string -> string option
+  val authenticate_encrypt_into : key:key -> nonce:string ->
+    ?adata:string -> string -> src_off:int -> bytes -> dst_off:int ->
+    tag_off:int -> int -> unit
+  val authenticate_decrypt_into : key:key -> nonce:string ->
+    ?adata:string -> string -> src_off:int -> tag_off:int -> bytes ->
+    dst_off:int -> int -> bool
+  val unsafe_authenticate_encrypt_into : key:key -> nonce:string ->
+    ?adata:string -> string -> src_off:int -> bytes -> dst_off:int ->
+    tag_off:int -> int -> unit
+  val unsafe_authenticate_decrypt_into : key:key -> nonce:string ->
+    ?adata:string -> string -> src_off:int -> tag_off:int -> bytes ->
+    dst_off:int -> int -> bool
 end

--- a/src/chacha20.ml
+++ b/src/chacha20.ml
@@ -93,11 +93,11 @@ let mac_into ~key ~adata src ~src_off len dst ~dst_off =
     Bytes.unsafe_to_string data
   in
   let p1 = pad16 (String.length adata) and p2 = pad16 len in
-  P.mac_into ~key [ adata, 0, String.length adata ;
-                    p1, 0, String.length p1 ;
-                    src, src_off, len ;
-                    p2, 0, String.length p2 ;
-                    len_buf, 0, String.length len_buf ]
+  P.unsafe_mac_into ~key [ adata, 0, String.length adata ;
+                           p1, 0, String.length p1 ;
+                           src, src_off, len ;
+                           p2, 0, String.length p2 ;
+                           len_buf, 0, String.length len_buf ]
     dst ~dst_off
 
 let unsafe_authenticate_encrypt_into ~key ~nonce ?(adata = "") src ~src_off dst ~dst_off ~tag_off len =

--- a/src/chacha20.ml
+++ b/src/chacha20.ml
@@ -65,7 +65,7 @@ let crypt_into ~key ~nonce ~ctr src ~src_off dst ~dst_off len =
       chacha20_block state (dst_off + i) dst ;
       Native.xor_into_bytes src (src_off + i) dst (dst_off + i) block ;
       inc state;
-      loop (i + block) (n - 1)
+      (loop [@tailcall]) (i + block) (n - 1)
   in
   loop 0 block_count
 

--- a/src/chacha20.ml
+++ b/src/chacha20.ml
@@ -100,11 +100,6 @@ let mac_into ~key ~adata src ~src_off len dst ~dst_off =
                     len_buf, 0, String.length len_buf ]
     dst ~dst_off
 
-let mac ~key ~adata ciphertext =
-  let r = Bytes.create tag_size in
-  mac_into ~key ~adata ciphertext ~src_off:0 (String.length ciphertext) r ~dst_off:0;
-  Bytes.unsafe_to_string r
-
 let unsafe_authenticate_encrypt_into ~key ~nonce ?(adata = "") src ~src_off dst ~dst_off ~tag_off len =
   let poly1305_key = generate_poly1305_key ~key ~nonce in
   crypt_into ~key ~nonce ~ctr:1L src ~src_off dst ~dst_off len;

--- a/src/chacha20.ml
+++ b/src/chacha20.ml
@@ -42,77 +42,126 @@ let init ctr ~key ~nonce =
   Bytes.unsafe_blit_string nonce 0 state nonce_off (String.length nonce) ;
   state, inc
 
-let crypt ~key ~nonce ?(ctr = 0L) data =
+let crypt_into ~key ~nonce ~ctr src ~src_off dst ~dst_off len =
   let state, inc = init ctr ~key ~nonce in
-  let l = String.length data in
-  let block_count = l // block in
+  let block_count = len // block in
   let last_len =
-    let last = l mod block in
+    let last = len mod block in
     if last = 0 then block else last
   in
-  let res = Bytes.create l in
   let rec loop i = function
     | 0 -> ()
     | 1 ->
       if last_len = block then begin
-        chacha20_block state i res ;
-        Native.xor_into_bytes data i res i block
+        chacha20_block state (dst_off + i) dst ;
+        Native.xor_into_bytes src (src_off + i) dst (dst_off + i) block
       end else begin
         let buf = Bytes.create block in
         chacha20_block state 0 buf ;
-        Native.xor_into_bytes data i buf 0 last_len ;
-        Bytes.unsafe_blit buf 0 res i last_len
+        Native.xor_into_bytes src (src_off + i) buf 0 last_len ;
+        Bytes.unsafe_blit buf 0 dst (dst_off + i) last_len
       end
     | n ->
-      chacha20_block state i res ;
-      Native.xor_into_bytes data i res i block ;
+      chacha20_block state (dst_off + i) dst ;
+      Native.xor_into_bytes src (src_off + i) dst (dst_off + i) block ;
       inc state;
       loop (i + block) (n - 1)
   in
-  loop 0 block_count ;
+  loop 0 block_count
+
+let crypt ~key ~nonce ?(ctr = 0L) data =
+  let l = String.length data in
+  let res = Bytes.create l in
+  crypt_into ~key ~nonce ~ctr data ~src_off:0 res ~dst_off:0 l;
   Bytes.unsafe_to_string res
 
 module P = Poly1305.It
 
+let tag_size = P.mac_size
+
 let generate_poly1305_key ~key ~nonce =
   crypt ~key ~nonce (String.make 32 '\000')
 
-let mac ~key ~adata ciphertext =
-  let pad16 b =
-    let len = String.length b mod 16 in
+let mac_into ~key ~adata src ~src_off len dst ~dst_off =
+  let pad16 l =
+    let len = l mod 16 in
     if len = 0 then "" else String.make (16 - len) '\000'
-  and len =
+  and len_buf =
     let data = Bytes.create 16 in
     Bytes.set_int64_le data 0 (Int64.of_int (String.length adata));
-    Bytes.set_int64_le data 8 (Int64.of_int (String.length ciphertext));
+    Bytes.set_int64_le data 8 (Int64.of_int len);
     Bytes.unsafe_to_string data
   in
-  P.macl ~key [ adata ; pad16 adata ; ciphertext ; pad16 ciphertext ; len ]
+  let p1 = pad16 (String.length adata) and p2 = pad16 len in
+  P.mac_into ~key [ adata, 0, String.length adata ;
+                    p1, 0, String.length p1 ;
+                    src, src_off, len ;
+                    p2, 0, String.length p2 ;
+                    len_buf, 0, String.length len_buf ]
+    dst ~dst_off
 
-let authenticate_encrypt_tag ~key ~nonce ?(adata = "") data =
+let mac ~key ~adata ciphertext =
+  let r = Bytes.create tag_size in
+  mac_into ~key ~adata ciphertext ~src_off:0 (String.length ciphertext) r ~dst_off:0;
+  Bytes.unsafe_to_string r
+
+let unsafe_authenticate_encrypt_into ~key ~nonce ?(adata = "") src ~src_off dst ~dst_off ~tag_off len =
   let poly1305_key = generate_poly1305_key ~key ~nonce in
-  let ciphertext = crypt ~key ~nonce ~ctr:1L data in
-  let mac = mac ~key:poly1305_key ~adata ciphertext in
-  ciphertext, mac
+  crypt_into ~key ~nonce ~ctr:1L src ~src_off dst ~dst_off len;
+  mac_into ~key:poly1305_key ~adata (Bytes.unsafe_to_string dst) ~src_off:dst_off len dst ~dst_off:tag_off
+
+let authenticate_encrypt_into ~key ~nonce ?adata src ~src_off dst ~dst_off ~tag_off len =
+  if String.length src - src_off < len then
+    invalid_arg "Chacha20: src length %u - src_off %u < len %u"
+      (String.length src) src_off len;
+  if Bytes.length dst - dst_off < len then
+    invalid_arg "Chacha20: dst length %u - dst_off %u < len %u"
+      (Bytes.length dst) dst_off len;
+  if Bytes.length dst - tag_off < tag_size then
+    invalid_arg "Chacha20: dst length %u - tag_off %u < tag_size %u"
+      (Bytes.length dst) tag_off tag_size;
+  unsafe_authenticate_encrypt_into ~key ~nonce ?adata src ~src_off dst ~dst_off ~tag_off len
 
 let authenticate_encrypt ~key ~nonce ?adata data =
-  let cdata, ctag = authenticate_encrypt_tag ~key ~nonce ?adata data in
-  cdata ^ ctag
+  let l = String.length data in
+  let dst = Bytes.create (l + tag_size) in
+  unsafe_authenticate_encrypt_into ~key ~nonce ?adata data ~src_off:0 dst ~dst_off:0 ~tag_off:l l;
+  Bytes.unsafe_to_string dst
 
-let authenticate_decrypt_tag ~key ~nonce ?(adata = "") ~tag data =
+let authenticate_encrypt_tag ~key ~nonce ?adata data =
+  let r = authenticate_encrypt ~key ~nonce ?adata data in
+  String.sub r 0 (String.length data), String.sub r (String.length data) tag_size
+
+let unsafe_authenticate_decrypt_into ~key ~nonce ?(adata = "") src ~src_off ~tag_off dst ~dst_off len =
   let poly1305_key = generate_poly1305_key ~key ~nonce in
-  let ctag = mac ~key:poly1305_key ~adata data in
-  let plain = crypt ~key ~nonce ~ctr:1L data in
-  if Eqaf.equal tag ctag then Some plain else None
+  let ctag = Bytes.create tag_size in
+  mac_into ~key:poly1305_key ~adata src ~src_off len ctag ~dst_off:0;
+  crypt_into ~key ~nonce ~ctr:1L src ~src_off dst ~dst_off len;
+  Eqaf.equal (String.sub src tag_off tag_size) (Bytes.unsafe_to_string ctag)
+
+let authenticate_decrypt_into ~key ~nonce ?adata src ~src_off ~tag_off dst ~dst_off len =
+  if String.length src - src_off < len then
+    invalid_arg "Chacha20: src length %u - src_off %u < len %u"
+      (String.length src) src_off len;
+  if Bytes.length dst - dst_off < len then
+    invalid_arg "Chacha20: dst length %u - dst_off %u < len %u"
+      (Bytes.length dst) dst_off len;
+  if String.length src - tag_off < tag_size then
+    invalid_arg "Chacha20: src length %u - tag_off %u < tag_size %u"
+      (String.length src) tag_off tag_size;
+  unsafe_authenticate_decrypt_into ~key ~nonce ?adata src ~src_off ~tag_off dst ~dst_off len
 
 let authenticate_decrypt ~key ~nonce ?adata data =
-  if String.length data < P.mac_size then
+  if String.length data < tag_size then
     None
   else
-    let cipher, tag =
-      let p = String.length data - P.mac_size in
-      String.sub data 0 p, String.sub data p P.mac_size
-    in
-    authenticate_decrypt_tag ~key ~nonce ?adata ~tag cipher
+    let l = String.length data - tag_size in
+    let r = Bytes.create l in
+    if unsafe_authenticate_decrypt_into ~key ~nonce ?adata data ~src_off:0 ~tag_off:l r ~dst_off:0 l then
+      Some (Bytes.unsafe_to_string r)
+    else
+      None
 
-let tag_size = P.mac_size
+let authenticate_decrypt_tag ~key ~nonce ?adata ~tag data =
+  let cdata = data ^ tag in
+  authenticate_decrypt ~key ~nonce ?adata cdata

--- a/src/cipher_block.ml
+++ b/src/cipher_block.ml
@@ -214,16 +214,16 @@ module Modes = struct
 
     let of_secret = Core.of_secret
 
-    let block_size_check ?(off = 0) ~iv cs =
+    let check_block_size ~iv len =
       if String.length iv <> block then
         invalid_arg "CBC: IV length %u not of block size" (String.length iv);
-      if (String.length cs - off) mod block <> 0 then
-        invalid_arg "CBC: argument length %u (off %u) not of block size"
-          (String.length cs) off
+      if len mod block <> 0 then
+        invalid_arg "CBC: argument length %u not of block size"
+          len
     [@@inline]
 
     let next_iv ?(off = 0) cs ~iv =
-      block_size_check ~iv cs ~off ;
+      check_block_size ~iv (String.length cs - off) ;
       if String.length cs > off then
         String.sub cs (String.length cs - block_size) block_size
       else iv
@@ -243,7 +243,7 @@ module Modes = struct
       unsafe_encrypt_into_inplace ~key ~iv dst ~dst_off len
 
     let encrypt_into ~key ~iv src ~src_off dst ~dst_off len =
-      block_size_check ~off:src_off ~iv src;
+      check_block_size ~iv len;
       check_offset ~tag:"CBC" ~buf:"src" ~off:src_off ~len (String.length src);
       check_offset ~tag:"CBC" ~buf:"dst" ~off:dst_off ~len (Bytes.length dst);
       unsafe_encrypt_into ~key ~iv src ~src_off dst ~dst_off len
@@ -262,7 +262,7 @@ module Modes = struct
       end
 
     let decrypt_into ~key ~iv src ~src_off dst ~dst_off len =
-      block_size_check ~off:src_off ~iv src;
+      check_block_size ~iv len;
       check_offset ~tag:"CBC" ~buf:"src" ~off:src_off ~len (String.length src);
       check_offset ~tag:"CBC" ~buf:"dst" ~off:dst_off ~len (Bytes.length dst);
       unsafe_decrypt_into ~key ~iv src ~src_off dst ~dst_off len

--- a/src/cipher_block.ml
+++ b/src/cipher_block.ml
@@ -99,7 +99,7 @@ module Counters = struct
     val size : int
     val add  : ctr -> int64 -> ctr
     val of_octets : string -> ctr
-    val unsafe_count_into : ctr -> bytes -> blocks:int -> unit
+    val unsafe_count_into : ctr -> bytes -> off:int -> blocks:int -> unit
   end
 
   module C64be = struct
@@ -107,10 +107,10 @@ module Counters = struct
     let size = 8
     let of_octets cs = String.get_int64_be cs 0
     let add = Int64.add
-    let unsafe_count_into t buf ~blocks =
-      let tmp = Bytes.create 8 in
-      Bytes.set_int64_be tmp 0 t;
-      Native.count8be tmp buf ~blocks
+    let unsafe_count_into t buf ~off ~blocks =
+      let ctr = Bytes.create 8 in
+      Bytes.set_int64_be ctr 0 t;
+      Native.count8be ~ctr buf ~off ~blocks
   end
 
   module C128be = struct
@@ -123,10 +123,10 @@ module Counters = struct
       let w0'  = Int64.add w0 n in
       let flip = if Int64.logxor w0 w0' < 0L then w0' > w0 else w0' < w0 in
       ((if flip then Int64.succ w1 else w1), w0')
-    let unsafe_count_into (w1, w0) buf ~blocks =
-      let tmp = Bytes.create 16 in
-      Bytes.set_int64_be tmp 0 w1; Bytes.set_int64_be tmp 8 w0;
-      Native.count16be tmp buf ~blocks
+    let unsafe_count_into (w1, w0) buf ~off ~blocks =
+      let ctr = Bytes.create 16 in
+      Bytes.set_int64_be ctr 0 w1; Bytes.set_int64_be ctr 8 w0;
+      Native.count16be ~ctr buf ~off ~blocks
   end
 
   module C128be32 = struct
@@ -134,10 +134,10 @@ module Counters = struct
     let add (w1, w0) n =
       let hi = 0xffffffff00000000L and lo = 0x00000000ffffffffL in
       (w1, Int64.(logor (logand hi w0) (add n w0 |> logand lo)))
-    let unsafe_count_into (w1, w0) buf ~blocks =
-      let tmp = Bytes.create 16 in
-      Bytes.set_int64_be tmp 0 w1; Bytes.set_int64_be tmp 8 w0;
-      Native.count16be4 tmp buf ~blocks
+    let unsafe_count_into (w1, w0) buf ~off ~blocks =
+      let ctr = Bytes.create 16 in
+      Bytes.set_int64_be ctr 0 w1; Bytes.set_int64_be ctr 8 w0;
+      Native.count16be4 ~ctr buf ~off ~blocks
   end
 end
 
@@ -280,13 +280,13 @@ module Modes = struct
     let stream ~key ~ctr n =
       let blocks = imax 0 n / block_size in
       let buf = Bytes.create n in
-      Ctr.unsafe_count_into ctr ~blocks buf ;
+      Ctr.unsafe_count_into ctr buf ~off:0 ~blocks ;
       Core.encrypt ~key ~blocks (Bytes.unsafe_to_string buf) 0 buf 0 ;
       let slack = imax 0 n mod block_size in
       if slack <> 0 then begin
         let buf' = Bytes.create block_size in
         let ctr = Ctr.add ctr (Int64.of_int blocks) in
-        Ctr.unsafe_count_into ctr ~blocks:1 buf' ;
+        Ctr.unsafe_count_into ctr buf' ~off:0 ~blocks:1 ;
         Core.encrypt ~key ~blocks:1 (Bytes.unsafe_to_string buf') 0 buf' 0 ;
         Bytes.unsafe_blit buf' 0 buf (blocks * block_size) slack
       end;

--- a/src/cipher_block.ml
+++ b/src/cipher_block.ml
@@ -234,7 +234,7 @@ module Modes = struct
         | b ->
           Native.xor_into_bytes iv iv_i dst dst_i block ;
           Core.encrypt ~key ~blocks:1 (Bytes.unsafe_to_string dst) dst_i dst dst_i ;
-          loop (Bytes.unsafe_to_string dst) dst_i (dst_i + block) (b - 1)
+          (loop [@tailcall]) (Bytes.unsafe_to_string dst) dst_i (dst_i + block) (b - 1)
       in
       loop iv 0 dst_off (len / block)
 

--- a/src/cipher_block.ml
+++ b/src/cipher_block.ml
@@ -363,7 +363,7 @@ module Modes = struct
 
   module GCM_of (C : Block.Core) : Block.GCM = struct
 
-    let _ = assert (C.block = 16)
+    assert (C.block = 16)
     module CTR = CTR_of (C) (Counters.C128be32)
 
     type key = { key : C.ekey ; hkey : GHASH.key }
@@ -455,9 +455,9 @@ module Modes = struct
 
   module CCM16_of (C : Block.Core) : Block.CCM16 = struct
 
-    let _ = assert (C.block = 16)
+    assert (C.block = 16)
 
-    let tag_size = 16
+    let tag_size = C.block
 
     type key = C.ekey
 
@@ -469,8 +469,8 @@ module Modes = struct
       C.encrypt ~key ~blocks:1 src src_off dst dst_off
 
     let unsafe_authenticate_encrypt_into ~key ~nonce ?(adata = "") src ~src_off dst ~dst_off ~tag_off len =
-      Ccm.unsafe_generation_encryption_into ~cipher ~key ~nonce ~maclen:tag_size
-        ~adata src ~src_off dst ~dst_off ~tag_off len
+      Ccm.unsafe_generation_encryption_into ~cipher ~key ~nonce ~adata
+        src ~src_off dst ~dst_off ~tag_off len
 
     let valid_nonce nonce =
       let nsize = String.length nonce in
@@ -496,7 +496,7 @@ module Modes = struct
       String.sub res 0 (String.length cs), String.sub res (String.length cs) tag_size
 
     let unsafe_authenticate_decrypt_into ~key ~nonce ?(adata = "") src ~src_off ~tag_off dst ~dst_off len =
-      Ccm.unsafe_decryption_verification_into ~cipher ~key ~nonce ~maclen:tag_size ~adata src ~src_off ~tag_off dst ~dst_off len
+      Ccm.unsafe_decryption_verification_into ~cipher ~key ~nonce ~adata src ~src_off ~tag_off dst ~dst_off len
 
     let authenticate_decrypt_into ~key ~nonce ?adata src ~src_off ~tag_off dst ~dst_off len =
       check_offset ~tag:"CCM" ~buf:"src" ~off:src_off ~len (String.length src);

--- a/src/cipher_stream.ml
+++ b/src/cipher_stream.ml
@@ -26,7 +26,7 @@ module ARC4 = struct
           let j = (j + si + x) land 0xff in
           let sj = s.(j) in
           s.(i) <- sj ; s.(j) <- si ;
-          loop j (succ i)
+          (loop [@tailcall]) j (succ i)
     in
     ( loop 0 0 ; (0, 0, s) )
 
@@ -44,7 +44,7 @@ module ARC4 = struct
           s.(i) <- sj ; s.(j) <- si ;
           let k  = s.((si + sj) land 0xff) in
           Bytes.set_uint8 res n (k lxor String.get_uint8 buf n);
-          mix i j (succ n)
+          (mix [@tailcall]) i j (succ n)
     in
     let key' = mix i j 0 in
     { key = key' ; message = Bytes.unsafe_to_string res }

--- a/src/mirage_crypto.mli
+++ b/src/mirage_crypto.mli
@@ -76,6 +76,11 @@ module Poly1305 : sig
 
   val mac_into : key:string -> (string * int * int) list -> bytes -> dst_off:int -> unit
   (** [mac_into ~key datas dst dst_off] computes the [mac] of [datas]. *)
+
+  (**/**)
+  val unsafe_mac_into : key:string -> (string * int * int) list -> bytes -> dst_off:int -> unit
+  (** [unsafe_mac_into ~key datas dst dst_off] is {!mac_into} without bounds checks. *)
+  (**/**)
 end
 
 (** {1 Symmetric-key cryptography} *)

--- a/src/mirage_crypto.mli
+++ b/src/mirage_crypto.mli
@@ -157,12 +157,70 @@ module Block : sig
   module type ECB = sig
 
     type key
+
     val of_secret : string -> key
+    (** Construct the encryption key corresponding to [secret].
+
+        @raise Invalid_argument if the length of [secret] is not in
+        {{!key_sizes}[key_sizes]}. *)
 
     val key_sizes  : int array
+    (** Key sizes allowed with this cipher. *)
+
     val block_size : int
+    (** The size of a single block. *)
+
     val encrypt : key:key -> string -> string
+    (** [encrypt ~key src] encrypts [src] into a freshly allocated buffer of the
+        same size using [key].
+
+        @raise Invalid_argument if the length of [src] is not a multiple of
+        {!block_size}. *)
+
     val decrypt : key:key -> string -> string
+    (** [decrypt ~key src] decrypts [src] into a freshly allocated buffer of the
+        same size using [key].
+
+        @raise Invalid_argument if the length of [src] is not a multiple of
+        {!block_size}. *)
+
+    val encrypt_into : key:key -> string -> src_off:int -> bytes -> dst_off:int -> int -> unit
+    (** [encrypt_into ~key src ~src_off dst dst_off len] encrypts [len] octets
+        from [src] starting at [src_off] into [dst] starting at [dst_off].
+
+        @raise Invalid_argument if [len] is not a multiple of {!block_size}.
+        @raise Invalid_argument if [String.length src - src_off < len].
+        @raise Invalid_argument if [Bytes.length dst - dst_off < len]. *)
+
+    val decrypt_into : key:key -> string -> src_off:int -> bytes -> dst_off:int -> int -> unit
+    (** [decrypt_into ~key src ~src_off dst dst_off len] decrypts [len] octets
+        from [src] starting at [src_off] into [dst] starting at [dst_off].
+
+        @raise Invalid_argument if [len] is not a multiple of {!block_size}.
+        @raise Invalid_argument if [String.length src - src_off < len].
+        @raise Invalid_argument if [Bytes.length dst - dst_off < len]. *)
+
+    (**/**)
+    val unsafe_encrypt_into : key:key -> string -> src_off:int -> bytes -> dst_off:int -> int -> unit
+    (** [unsafe_encrypt_into ~key src ~src_off dst dst_off len] encrypts [len]
+        octets from [src] starting at [src_off] into [dst] starting at
+        [dst_off]. Since buffer lengths and block sizes are not checked, this
+        may cause memory issues if an invariant is violated:
+        {ul
+        {- [len] must be a multiple of {!block_size},}
+        {- [String.length src - src_off >= len],}
+        {- [Bytes.length dst - dst_off >= len].}} *)
+
+    val unsafe_decrypt_into : key:key -> string -> src_off:int -> bytes -> dst_off:int -> int -> unit
+    (** [unsafe_decrypt_into ~key src ~src_off dst dst_off len] decrypts [len]
+        octets from [src] starting at [src_off] into [dst] starting at
+        [dst_off]. Since buffer lengths and block sizes are not checked, this
+        may cause memory issues if an invariant is violated:
+        {ul
+        {- [len] must be a multiple of {!block_size},}
+        {- [String.length src - src_off >= len],}
+        {- [Bytes.length dst - dst_off >= len].}} *)
+    (**/**)
   end
 
   (** {e Cipher-block chaining} mode. *)

--- a/src/mirage_crypto.mli
+++ b/src/mirage_crypto.mli
@@ -148,7 +148,7 @@ module type AEAD = sig
     ?adata:string -> string -> src_off:int -> bytes -> dst_off:int ->
     tag_off:int -> int -> unit
   (** [authenticate_encrypt_into ~key ~nonce ~adata msg ~src_off dst ~dst_off ~tag_off len]
-      encrypts [msg] starting at [src_off] with [key] and [nonce]. The output
+      encrypts [len] bytes of [msg] starting at [src_off] with [key] and [nonce]. The output
       is put into [dst] at [dst_off], the tag into [dst] at [tag_off].
 
       @raise Invalid_argument if [nonce] is not of the right size.
@@ -160,9 +160,9 @@ module type AEAD = sig
   val authenticate_decrypt_into : key:key -> nonce:string ->
     ?adata:string -> string -> src_off:int -> tag_off:int -> bytes ->
     dst_off:int -> int -> bool
-  (** [authenticate_decrypt_into ~key ~nonce ~adata msg ~src_off ~tag_off dst ~dst_off]
+  (** [authenticate_decrypt_into ~key ~nonce ~adata msg ~src_off ~tag_off dst ~dst_off len]
       computes the authentication tag using [key], [nonce], and [adata], and
-      decrypts the encrypted data from [msg] starting at [src_off] into [dst]
+      decrypts the [len] bytes encrypted data from [msg] starting at [src_off] into [dst]
       starting at [dst_off]. If the authentication tags match, [true] is
       returned, and the decrypted data is in [dst].
 

--- a/src/mirage_crypto.mli
+++ b/src/mirage_crypto.mli
@@ -248,16 +248,16 @@ module Block : sig
         from [src] starting at [src_off] into [dst] starting at [dst_off].
 
         @raise Invalid_argument if [len] is not a multiple of {!block_size}.
-        @raise Invalid_argument if [String.length src - src_off < len].
-        @raise Invalid_argument if [Bytes.length dst - dst_off < len]. *)
+        @raise Invalid_argument if [src_off < 0 || String.length src - src_off < len].
+        @raise Invalid_argument if [dst_off < 0 || Bytes.length dst - dst_off < len]. *)
 
     val decrypt_into : key:key -> string -> src_off:int -> bytes -> dst_off:int -> int -> unit
     (** [decrypt_into ~key src ~src_off dst dst_off len] decrypts [len] octets
         from [src] starting at [src_off] into [dst] starting at [dst_off].
 
         @raise Invalid_argument if [len] is not a multiple of {!block_size}.
-        @raise Invalid_argument if [String.length src - src_off < len].
-        @raise Invalid_argument if [Bytes.length dst - dst_off < len]. *)
+        @raise Invalid_argument if [src_off < 0 || String.length src - src_off < len].
+        @raise Invalid_argument if [dst_off < 0 || Bytes.length dst - dst_off < len]. *)
 
     (**/**)
     val unsafe_encrypt_into : key:key -> string -> src_off:int -> bytes -> dst_off:int -> int -> unit
@@ -266,8 +266,8 @@ module Block : sig
         This may cause memory issues if an invariant is violated:
         {ul
         {- [len] must be a multiple of {!block_size},}
-        {- [String.length src - src_off >= len],}
-        {- [Bytes.length dst - dst_off >= len].}} *)
+        {- [src_off >= 0 && String.length src - src_off >= len],}
+        {- [dst_off >= 0 && Bytes.length dst - dst_off >= len].}} *)
 
     val unsafe_decrypt_into : key:key -> string -> src_off:int -> bytes -> dst_off:int -> int -> unit
     (** [unsafe_decrypt_into] is {!decrypt_into}, but without bounds checks.
@@ -275,8 +275,8 @@ module Block : sig
         This may cause memory issues if an invariant is violated:
         {ul
         {- [len] must be a multiple of {!block_size},}
-        {- [String.length src - src_off >= len],}
-        {- [Bytes.length dst - dst_off >= len].}} *)
+        {- [src_off >= 0 && String.length src - src_off >= len],}
+        {- [dst_off >= 0 && Bytes.length dst - dst_off >= len].}} *)
     (**/**)
   end
 
@@ -334,8 +334,8 @@ module Block : sig
 
         @raise Invalid_argument if the length of [iv] is not {!block_size}.
         @raise Invalid_argument if [len] is not a multiple of {!block_size}.
-        @raise Invalid_argument if [String.length src - src_off < len].
-        @raise Invalid_argument if [Bytes.length dst - dst_off < len]. *)
+        @raise Invalid_argument if [src_off < 0 || String.length src - src_off < len].
+        @raise Invalid_argument if [dst_off < 0 || Bytes.length dst - dst_off < len]. *)
 
     val decrypt_into : key:key -> iv:string -> string -> src_off:int ->
       bytes -> dst_off:int -> int -> unit
@@ -344,8 +344,8 @@ module Block : sig
 
         @raise Invalid_argument if the length of [iv] is not {!block_size}.
         @raise Invalid_argument if [len] is not a multiple of {!block_size}.
-        @raise Invalid_argument if [String.length src - src_off < len].
-        @raise Invalid_argument if [Bytes.length dst - dst_off < len]. *)
+        @raise Invalid_argument if [src_off < 0 || String.length src - src_off < len].
+        @raise Invalid_argument if [dst_off < 0 || Bytes.length dst - dst_off < len]. *)
 
     (**/**)
     val unsafe_encrypt_into : key:key -> iv:string -> string -> src_off:int ->
@@ -356,8 +356,8 @@ module Block : sig
         {ul
         {- the length of [iv] must be {!block_size},}
         {- [len] must be a multiple of {!block_size},}
-        {- [String.length src - src_off >= len],}
-        {- [Bytes.length dst - dst_off >= len].}} *)
+        {- [src_off >= 0 && String.length src - src_off >= len],}
+        {- [dst_off >= 0 && Bytes.length dst - dst_off >= len].}} *)
 
     val unsafe_decrypt_into : key:key -> iv:string -> string -> src_off:int ->
       bytes -> dst_off:int -> int -> unit
@@ -367,8 +367,8 @@ module Block : sig
         {ul
         {- the length of [iv] must be {!block_size},}
         {- [len] must be a multiple of {!block_size},}
-        {- [String.length src - src_off >= len],}
-        {- [Bytes.length dst - dst_off >= len].}} *)
+        {- [src_off >= 0 && String.length src - src_off >= len],}
+        {- [dst_off >= 0 && Bytes.length dst - dst_off >= len].}} *)
 
     val unsafe_encrypt_into_inplace : key:key -> iv:string ->
       bytes -> dst_off:int -> int -> unit
@@ -379,8 +379,8 @@ module Block : sig
         {ul
         {- the length of [iv] must be {!block_size},}
         {- [len] must be a multiple of {!block_size},}
-        {- [String.length src - src_off >= len],}
-        {- [Bytes.length dst - dst_off >= len].}} *)
+        {- [src_off >= 0 && String.length src - src_off >= len],}
+        {- [dst_off >= 0 && Bytes.length dst - dst_off >= len].}} *)
     (**/**)
 end
 
@@ -459,8 +459,8 @@ end
         key stream into [dst] at [dst_off], and then xors it with [src] at
         [src_off].
 
-        @raise Invalid_argument if [Bytes.length dst - off < len].
-        @raise Invalid_argument if [String.length src - off < len]. *)
+        @raise Invalid_argument if [dst_off < 0 || Bytes.length dst - dst_off < len].
+        @raise Invalid_argument if [src_off < 0 || String.length src - src_off < len]. *)
 
     val decrypt_into : key:key -> ctr:ctr -> string -> src_off:int ->
       bytes -> dst_off:int -> int -> unit
@@ -472,7 +472,7 @@ end
 
         This may cause memory issues if the invariant is violated:
         {ul
-        {- [Bytes.length buf - off >= len].}} *)
+        {- [off >= 0 && Bytes.length buf - off >= len].}} *)
 
     val unsafe_encrypt_into : key:key -> ctr:ctr -> string -> src_off:int ->
       bytes -> dst_off:int -> int -> unit
@@ -480,8 +480,8 @@ end
 
         This may cause memory issues if an invariant is violated:
         {ul
-        {- [Bytes.length dst - off >= len],}
-        {- [String.length src - off < len].}} *)
+        {- [dst_off >= 0 && Bytes.length dst - dst_off >= len],}
+        {- [src_off >= 0 && String.length src - src_off >= len].}} *)
 
     val unsafe_decrypt_into : key:key -> ctr:ctr -> string -> src_off:int ->
       bytes -> dst_off:int -> int -> unit

--- a/src/native.ml
+++ b/src/native.ml
@@ -20,8 +20,8 @@ end
 
 module Poly1305 = struct
   external init     : bytes -> string -> unit = "mc_poly1305_init" [@@noalloc]
-  external update   : bytes -> string -> int -> unit = "mc_poly1305_update" [@@noalloc]
-  external finalize : bytes -> bytes -> unit = "mc_poly1305_finalize" [@@noalloc]
+  external update   : bytes -> string -> int -> int -> unit = "mc_poly1305_update" [@@noalloc]
+  external finalize : bytes -> bytes -> int -> unit = "mc_poly1305_finalize" [@@noalloc]
   external ctx_size : unit -> int = "mc_poly1305_ctx_size" [@@noalloc]
   external mac_size : unit -> int = "mc_poly1305_mac_size" [@@noalloc]
 end
@@ -29,7 +29,7 @@ end
 module GHASH = struct
   external keysize : unit -> int = "mc_ghash_key_size" [@@noalloc]
   external keyinit : string -> bytes -> unit = "mc_ghash_init_key" [@@noalloc]
-  external ghash : string -> bytes -> string -> int -> unit = "mc_ghash" [@@noalloc]
+  external ghash : string -> bytes -> string -> int -> int -> unit = "mc_ghash" [@@noalloc]
   external mode : unit -> int = "mc_ghash_mode" [@@noalloc]
 end
 

--- a/src/native.ml
+++ b/src/native.ml
@@ -37,9 +37,9 @@ end
  * Unsolved: bounds-checked XORs are slowing things down considerably... *)
 external xor_into_bytes : string -> int -> bytes -> int -> int -> unit = "mc_xor_into_bytes" [@@noalloc]
 
-external count8be   : bytes -> bytes -> blocks:int -> unit = "mc_count_8_be"    [@@noalloc]
-external count16be  : bytes -> bytes -> blocks:int -> unit = "mc_count_16_be"   [@@noalloc]
-external count16be4 : bytes -> bytes -> blocks:int -> unit = "mc_count_16_be_4" [@@noalloc]
+external count8be   : ctr:bytes -> bytes -> off:int -> blocks:int -> unit = "mc_count_8_be"    [@@noalloc]
+external count16be  : ctr:bytes -> bytes -> off:int -> blocks:int -> unit = "mc_count_16_be"   [@@noalloc]
+external count16be4 : ctr:bytes -> bytes -> off:int -> blocks:int -> unit = "mc_count_16_be_4" [@@noalloc]
 
 external misc_mode : unit -> int = "mc_misc_mode" [@@noalloc]
 

--- a/src/native/ghash_ctmul.c
+++ b/src/native/ghash_ctmul.c
@@ -290,8 +290,8 @@ CAMLprim value mc_ghash_init_key_generic (value key, value m) {
   return Val_unit;
 }
 
-CAMLprim value mc_ghash_generic (value m, value hash, value src, value len) {
-  br_ghash_ctmul(Bp_val(hash), Bp_val(m), _st_uint8(src), Int_val(len));
+CAMLprim value mc_ghash_generic (value m, value hash, value src, value off, value len) {
+  br_ghash_ctmul(Bp_val(hash), Bp_val(m), _st_uint8_off(src, off), Int_val(len));
   return Val_unit;
 }
 

--- a/src/native/ghash_generic.c
+++ b/src/native/ghash_generic.c
@@ -101,9 +101,9 @@ CAMLprim value mc_ghash_init_key_generic (value key, value m) {
 }
 
 CAMLprim value
-mc_ghash_generic (value m, value hash, value src, value len) {
+mc_ghash_generic (value m, value hash, value src, value off, value len) {
   __ghash ((__uint128_t *) Bp_val (m), (uint64_t *) Bp_val (hash),
-           _st_uint8 (src), Int_val (len) );
+           _st_uint8_off (src, off), Int_val (len) );
   return Val_unit;
 }
 

--- a/src/native/ghash_pclmul.c
+++ b/src/native/ghash_pclmul.c
@@ -204,11 +204,11 @@ CAMLprim value mc_ghash_init_key (value key, value m) {
 }
 
 CAMLprim value
-mc_ghash (value k, value hash, value src, value len) {
+mc_ghash (value k, value hash, value src, value off, value len) {
   _mc_switch_accel(pclmul,
-    mc_ghash_generic(k, hash, src, len),
+    mc_ghash_generic(k, hash, src, off, len),
     __ghash ( (__m128i *) Bp_val (k), (__m128i *) Bp_val (hash),
-      (__m128i *) _st_uint8 (src), Int_val (len) ))
+              (__m128i *) _st_uint8_off (src, off), Int_val (len) ))
   return Val_unit;
 }
 

--- a/src/native/mirage_crypto.h
+++ b/src/native/mirage_crypto.h
@@ -105,7 +105,7 @@ CAMLprim value mc_ghash_key_size_generic (__unit ());
 CAMLprim value mc_ghash_init_key_generic (value key, value m);
 
 CAMLprim value
-mc_ghash_generic (value m, value hash, value src, value len);
+mc_ghash_generic (value m, value hash, value src, value off, value len);
 
 CAMLprim value
 mc_xor_into_generic (value b1, value off1, value b2, value off2, value n);

--- a/src/native/mirage_crypto.h
+++ b/src/native/mirage_crypto.h
@@ -114,6 +114,6 @@ CAMLprim value
 mc_xor_into_bytes_generic (value b1, value off1, value b2, value off2, value n);
 
 CAMLprim value
-mc_count_16_be_4_generic (value ctr, value dst, value blocks);
+mc_count_16_be_4_generic (value ctr, value dst, value off, value blocks);
 
 #endif /* H__MIRAGE_CRYPTO */

--- a/src/native/misc.c
+++ b/src/native/misc.c
@@ -60,9 +60,9 @@ mc_xor_into_bytes_generic (value b1, value off1, value b2, value off2, value n) 
 }
 
 #define __export_counter(name, f)                                        \
-  CAMLprim value name (value ctr, value dst, value blocks) {  \
+  CAMLprim value name (value ctr, value dst, value off, value blocks) {  \
     f ( (uint64_t*) Bp_val (ctr),                                        \
-        (uint64_t*) _bp_uint8 (dst), Long_val (blocks) );       \
+        (uint64_t*) _bp_uint8_off (dst, off), Long_val (blocks) );       \
     return Val_unit;                                                     \
   }
 

--- a/src/native/misc_sse.c
+++ b/src/native/misc_sse.c
@@ -48,11 +48,11 @@ mc_xor_into_bytes (value b1, value off1, value b2, value off2, value n) {
 }
 
 #define __export_counter(name, f)                                        \
-  CAMLprim value name (value ctr, value dst, value blocks) {  \
-    _mc_switch_accel(ssse3,                                     \
-      name##_generic (ctr, dst, blocks),                            \
+  CAMLprim value name (value ctr, value dst, value off, value blocks) {  \
+    _mc_switch_accel(ssse3,                                              \
+      name##_generic (ctr, dst, off, blocks),                            \
       f ( (uint64_t*) Bp_val (ctr),                                      \
-          (uint64_t*) _bp_uint8 (dst), Long_val (blocks) ))     \
+          (uint64_t*) _bp_uint8_off (dst, off), Long_val (blocks) ))     \
     return Val_unit;                                                     \
   }
 

--- a/src/native/poly1305-donna.c
+++ b/src/native/poly1305-donna.c
@@ -59,13 +59,13 @@ CAMLprim value mc_poly1305_init (value ctx, value key) {
   return Val_unit;
 }
 
-CAMLprim value mc_poly1305_update (value ctx, value buf, value len) {
-  poly1305_update ((poly1305_context *) Bytes_val(ctx), _st_uint8(buf), Int_val(len));
+CAMLprim value mc_poly1305_update (value ctx, value buf, value off, value len) {
+  poly1305_update ((poly1305_context *) Bytes_val(ctx), _st_uint8_off(buf, off), Int_val(len));
   return Val_unit;
 }
 
-CAMLprim value mc_poly1305_finalize (value ctx, value mac) {
-  poly1305_finish ((poly1305_context *) Bytes_val(ctx), Bytes_val(mac));
+CAMLprim value mc_poly1305_finalize (value ctx, value mac, value off) {
+  poly1305_finish ((poly1305_context *) Bytes_val(ctx), _bp_uint8_off(mac, off));
   return Val_unit;
 }
 

--- a/src/poly1305.ml
+++ b/src/poly1305.ml
@@ -11,7 +11,7 @@ module type S = sig
 
   val mac : key:string -> string -> string
   val maci : key:string -> string iter -> string
-  val macl : key:string -> string list -> string
+  val mac_into : key:string -> (string * int * int) list -> bytes -> dst_off:int -> unit
 end
 
 module It : S = struct
@@ -31,7 +31,7 @@ module It : S = struct
     ctx
 
   let update ctx data =
-    P.update ctx data (String.length data)
+    P.update ctx data 0 (String.length data)
 
   let feed ctx cs =
     let t = dup ctx in
@@ -45,7 +45,7 @@ module It : S = struct
 
   let final ctx =
     let res = Bytes.create mac_size in
-    P.finalize ctx res;
+    P.finalize ctx res 0;
     Bytes.unsafe_to_string res
 
   let get ctx = final (dup ctx)
@@ -54,8 +54,8 @@ module It : S = struct
 
   let maci ~key iter = feedi (empty ~key) iter |> final
 
-  let macl ~key datas =
+  let mac_into ~key datas dst ~dst_off =
     let ctx = empty ~key in
-    List.iter (update ctx) datas;
-    final ctx
+    List.iter (fun (d, off, len) -> P.update ctx d off len) datas;
+    P.finalize ctx dst dst_off
 end


### PR DESCRIPTION
This avoids buffer allocations. There are as well unsafe functions exposed for elevated performance.

Reviews welcome, this is WIP since for now only ECB and ECB modes have this new interface (still missing CTR, GCM, CCM). Will continue work on that. Will superseed #204 (at a future point in time).