### PR TITLE
Require OCaml 4.13 and remove local overrides

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ocaml-version: ["4.14.2", "4.13.1", "4.12.1"]
+        ocaml-version: ["4.14.2", "4.13.1"]
         operating-system: [macos-latest, ubuntu-latest]
 
     runs-on: ${{ matrix.operating-system }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ocaml-version: ["4.14.2", "4.13.1", "4.12.1"]
+        ocaml-version: ["4.14.2", "4.13.1"]
         operating-system: [windows-latest]
 
     runs-on: ${{ matrix.operating-system }}

--- a/mirage-crypto-ec.opam
+++ b/mirage-crypto-ec.opam
@@ -27,7 +27,7 @@ doc: "https://mirage.github.io/mirage-crypto/doc"
 bug-reports: "https://github.com/mirage/mirage-crypto/issues"
 depends: [
   "dune" {>= "2.7"}
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.13.0"}
   "dune-configurator"
   "eqaf" {>= "0.7"}
   "mirage-crypto-rng" {=version}

--- a/mirage-crypto-pk.opam
+++ b/mirage-crypto-pk.opam
@@ -14,7 +14,7 @@ build: [ ["dune" "subst"] {dev}
 
 depends: [
   "conf-gmp-powm-sec" {build}
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.13.0"}
   "dune" {>= "2.7"}
   "ounit2" {with-test}
   "randomconv" {with-test & >= "0.2.0"}

--- a/mirage-crypto-rng-async.opam
+++ b/mirage-crypto-rng-async.opam
@@ -13,7 +13,7 @@ build: [ ["dune" "subst"] {dev}
          ["dune" "runtest" "-p" name "-j" jobs] {with-test} ]
 
 depends: [
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.13.0"}
   "dune" {>= "2.7"}
   "dune-configurator" {>= "2.0.0"}
   "async" {>= "v0.14"}

--- a/mirage-crypto-rng-lwt.opam
+++ b/mirage-crypto-rng-lwt.opam
@@ -13,7 +13,7 @@ build: [ ["dune" "subst"] {dev}
          ["dune" "runtest" "-p" name "-j" jobs] {with-test} ]
 
 depends: [
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.13.0"}
   "dune" {>= "2.7"}
   "duration"
   "logs"

--- a/mirage-crypto-rng-mirage.opam
+++ b/mirage-crypto-rng-mirage.opam
@@ -13,7 +13,7 @@ build: [ ["dune" "subst"] {dev}
          ["dune" "runtest" "-p" name "-j" jobs] {with-test} ]
 
 depends: [
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.13.0"}
   "dune" {>= "2.7"}
   "mirage-crypto-rng" {=version}
   "duration"

--- a/mirage-crypto-rng.opam
+++ b/mirage-crypto-rng.opam
@@ -13,7 +13,7 @@ build: [ ["dune" "subst"] {dev}
          ["dune" "runtest" "-p" name "-j" jobs] {with-test} ]
 
 depends: [
-  "ocaml" {>= "4.12.0"}
+  "ocaml" {>= "4.13.0"}
   "dune" {>= "2.7"}
   "dune-configurator" {>= "2.0.0"}
   "duration"

--- a/mirage-crypto.opam
+++ b/mirage-crypto.opam
@@ -13,7 +13,7 @@ build: [ ["dune" "subst"] {dev}
          ["dune" "runtest" "-p" name "-j" jobs] {with-test} ]
 
 depends: [
-  "ocaml" {>= "4.09.0"}
+  "ocaml" {>= "4.13.0"}
   "dune" {>= "2.7"}
   "dune-configurator" {>= "2.0.0"}
   "ounit2" {with-test}

--- a/pk/z_extra.ml
+++ b/pk/z_extra.ml
@@ -2,37 +2,24 @@ open Mirage_crypto.Uncommon
 
 let bit_bound z = Z.size z * 64
 
-(* revise once OCaml 4.13 is the lower bound *)
-let string_get_int64_be buf idx =
-  Bytes.get_int64_be (Bytes.unsafe_of_string buf) idx
-
-let string_get_int32_be buf idx =
-  Bytes.get_int32_be (Bytes.unsafe_of_string buf) idx
-
-let string_get_uint16_be buf idx =
-  Bytes.get_uint16_be (Bytes.unsafe_of_string buf) idx
-
-let string_get_uint8 buf idx =
-  Bytes.get_uint8 (Bytes.unsafe_of_string buf) idx
-
 let of_octets_be ?bits buf =
   let rec loop acc i = function
     | b when b >= 64 ->
-      let x = string_get_int64_be buf i in
+      let x = String.get_int64_be buf i in
       let x = Z.of_int64_unsigned Int64.(shift_right_logical x 8) in
       loop Z.(x + acc lsl 56) (i + 7) (b - 56)
     | b when b >= 32 ->
-      let x = string_get_int32_be buf i in
+      let x = String.get_int32_be buf i in
       let x = Z.of_int32_unsigned Int32.(shift_right_logical x 8) in
       loop Z.(x + acc lsl 24) (i + 3) (b - 24)
     | b when b >= 16 ->
-      let x = Z.of_int (string_get_uint16_be buf i) in
+      let x = Z.of_int (String.get_uint16_be buf i) in
       loop Z.(x + acc lsl 16) (i + 2) (b - 16)
     | b when b >= 8  ->
-      let x = Z.of_int (string_get_uint8 buf i) in
+      let x = Z.of_int (String.get_uint8 buf i) in
       loop Z.(x + acc lsl 8 ) (i + 1) (b - 8 )
     | b when b > 0   ->
-      let x = string_get_uint8 buf i and b' = 8 - b in
+      let x = String.get_uint8 buf i and b' = 8 - b in
       Z.(of_int x asr b' + acc lsl b)
     | _              -> acc in
   loop Z.zero 0 @@ match bits with

--- a/src/cipher_block.ml
+++ b/src/cipher_block.ml
@@ -89,8 +89,7 @@ module Counters = struct
   module C64be = struct
     type ctr = int64
     let size = 8
-    (* Until OCaml 4.13 is lower bound*)
-    let of_octets cs = Bytes.get_int64_be (Bytes.unsafe_of_string cs) 0
+    let of_octets cs = String.get_int64_be cs 0
     let add = Int64.add
     let unsafe_count_into t buf ~blocks =
       let tmp = Bytes.create 8 in
@@ -277,16 +276,10 @@ module Modes = struct
       Bytes.set_int64_be cs 8 b;
       Bytes.unsafe_to_string cs
 
-    (* OCaml 4.13 *)
-    let string_get_int64 s idx =
-      Bytes.get_int64_be (Bytes.unsafe_of_string s) idx
-    let string_get_int32 s idx =
-      Bytes.get_int32_be (Bytes.unsafe_of_string s) idx
-
     let counter ~hkey nonce = match String.length nonce with
       | 0 -> invalid_arg "GCM: invalid nonce of length 0"
       | 12 ->
-        let (w1, w2) = string_get_int64 nonce 0, string_get_int32 nonce 8 in
+        let (w1, w2) = String.get_int64_be nonce 0, String.get_int32_be nonce 8 in
         (w1, Int64.(shift_left (of_int32 w2) 32 |> add 1L))
       | _  ->
         CTR.ctr_of_octets @@

--- a/src/cipher_stream.ml
+++ b/src/cipher_stream.ml
@@ -21,7 +21,7 @@ module ARC4 = struct
     let rec loop j = function
       | 256 -> ()
       | i ->
-          let x = string_get_uint8 buf (i mod len) in
+          let x = String.get_uint8 buf (i mod len) in
           let si = s.(i) in
           let j = (j + si + x) land 0xff in
           let sj = s.(j) in
@@ -43,7 +43,7 @@ module ARC4 = struct
           let sj = s.(j) in
           s.(i) <- sj ; s.(j) <- si ;
           let k  = s.((si + sj) land 0xff) in
-          Bytes.set_uint8 res n (k lxor string_get_uint8 buf n);
+          Bytes.set_uint8 res n (k lxor String.get_uint8 buf n);
           mix i j (succ n)
     in
     let key' = mix i j 0 in

--- a/src/uncommon.ml
+++ b/src/uncommon.ml
@@ -25,7 +25,3 @@ let xor a b =
   let b' = Bytes.of_string b in
   xor_into a ~src_off:0 b' ~dst_off:0 (Bytes.length b');
   Bytes.unsafe_to_string b'
-
-(* revise once OCaml 4.13 is the lower bound *)
-let string_get_uint8 buf idx =
-    Bytes.get_uint8 (Bytes.unsafe_of_string buf) idx

--- a/tests/test_ec_wycheproof.ml
+++ b/tests/test_ec_wycheproof.ml
@@ -4,14 +4,6 @@ open Mirage_crypto_ec
 
 let ( let* ) = Result.bind
 
-let concat_map f l =
-  (* adapt once OCaml 4.10 is lower bound *)
-  List.map f l |> List.concat
-
-let string_get_uint8 d off =
-  (* adapt once OCaml 4.13 is lower bound *)
-  Bytes.get_uint8 (Bytes.unsafe_of_string d) off
-
 let hex = Alcotest.testable Wycheproof.pp_hex Wycheproof.equal_hex
 
 module Asn = struct
@@ -155,8 +147,8 @@ let ecdh_tests file =
   let groups : ecdh_test_group list =
     List.map ecdh_test_group_exn data.testGroups
   in
-  concat_map (fun (group : ecdh_test_group) ->
-      concat_map (to_ecdh_tests group.curve) group.tests)
+  List.concat_map (fun (group : ecdh_test_group) ->
+      List.concat_map (to_ecdh_tests group.curve) group.tests)
     groups
 
 let make_ecdsa_test curve key hash (tst : dsa_test) =
@@ -219,7 +211,7 @@ let ecdsa_tests file =
   let groups : ecdsa_test_group list =
     List.map ecdsa_test_group_exn data.testGroups
   in
-  concat_map to_ecdsa_tests groups
+  List.concat_map to_ecdsa_tests groups
 
 let to_x25519_test (x : ecdh_test) =
   let name = Printf.sprintf "%d - %s" x.tcId x.comment
@@ -262,7 +254,7 @@ let x25519_tests =
   let groups : ecdh_test_group list =
     List.map ecdh_test_group_exn data.testGroups
   in
-  concat_map (fun (group : ecdh_test_group) ->
+  List.concat_map (fun (group : ecdh_test_group) ->
       List.map to_x25519_test group.tests)
     groups
 
@@ -297,7 +289,7 @@ let ed25519_tests =
   let groups : eddsa_test_group list =
     List.map eddsa_test_group_exn data.testGroups
   in
-  concat_map (fun (group : eddsa_test_group) ->
+  List.concat_map (fun (group : eddsa_test_group) ->
       let keys = to_ed25519_keys group.key in
       List.map (to_ed25519_test keys) group.tests)
     groups


### PR DESCRIPTION
~~somehow this seems to require on my laptop the `(modes native)` for all the test executables, as proposed in https://github.com/mirage/mirage-crypto/pull/227/commits/764ccde05e8e866d1ab79620b2aa3f3aedd66dad (part of #227)~~

just a dune issue, https://github.com/ocaml/dune/issues/9979 -- let's not bother