### PR TITLE
cpu cycles: on arm64 use clock_gettime and PMCCNTR_EL0 for freestanding

### DIFF
--- a/src/native/entropy_cpu_stubs.c
+++ b/src/native/entropy_cpu_stubs.c
@@ -111,14 +111,23 @@ static inline uint32_t read_virtual_count (void)
 #endif /* arm */
 
 #if defined (__aarch64__)
-#define	isb() __asm__ __volatile__("isb" : : : "memory")
+#if defined(__ocaml_freestanding__) || defined(__ocaml_solo5__)
 static inline uint64_t read_virtual_count(void)
 {
   uint64_t c;
-  isb();
-  __asm__ __volatile__("mrs %0, cntvct_el0":"=r"(c));
+  __asm__ __volatile__("mrs %0, PMCCNTR_EL0":"=r"(c));
   return c;
 }
+#else
+/* see https://github.com/mirage/mirage-crypto/issues/216 */
+#include <time.h>
+static inline uint64_t read_virtual_count (void)
+{
+  struct timespec now;
+  clock_gettime (CLOCK_MONOTONIC, &now);
+  return now.tv_nsec;
+}
+#endif /* __ocaml_freestanding__ || __ocaml_solo5__ */
 #endif /* aarch64 */
 
 #if defined (__powerpc64__)


### PR DESCRIPTION
previously, cntvct_el0 was used which is capped to 24 MHz, leading to entropy test failures on macOS and linux-aarch64. The PMCCNTR_EL0 is not available in user-space normally (for Linux, there is a kernel module).

So, what we do is similar to the ARM32 code path now.

Fixes #216