### PR TITLE
Mingw friendly case for includes.

### DIFF
--- a/rng/unix/mc_getrandom_stubs.c
+++ b/rng/unix/mc_getrandom_stubs.c
@@ -57,7 +57,7 @@ void raw_getrandom (uint8_t *data, uint32_t len) {
  * have decided to go with the more modern Windows API with bcrypt,
  * and make Windows 10 our minimum supported version of mirage-crypto.
  */
-#include <Windows.h>
+#include <windows.h>
 #include <ntstatus.h>
 #include <bcrypt.h>
 


### PR DESCRIPTION
Since windows filesystem is case insensitive and, AFAIK, `windows.h` is always lowercase in MinGW distributions, using a lowercase include will work on both transparently.

Currently:

```
mc_getrandom_stubs.c:60:10: fatal error: Windows.h: No such file or directory
   60 | #include <Windows.h>
      |          ^~~~~~~~~~~
```