### PR TITLE
Handle CPU_RNG failures in OCaml:

### DIFF
--- a/rng/async/mirage_crypto_rng_async.ml
+++ b/rng/async/mirage_crypto_rng_async.ml
@@ -34,7 +34,7 @@ let periodically_collect_getrandom_entropy time_source span =
       let idx = ref 0 in
       let f () =
         incr idx;
-        String.sub random ~pos:(per_pool * (pred !idx)) ~len:per_pool
+        Ok (String.sub random ~pos:(per_pool * (pred !idx)) ~len:per_pool)
       in
       Entropy.feed_pools None source f)
 

--- a/rng/dune
+++ b/rng/dune
@@ -1,5 +1,5 @@
 (library
  (name mirage_crypto_rng)
  (public_name mirage-crypto-rng)
- (libraries mirage-crypto digestif)
+ (libraries mirage-crypto digestif logs)
  (private_modules entropy fortuna hmac_drbg rng))

--- a/rng/eio/mirage_crypto_rng_eio.ml
+++ b/rng/eio/mirage_crypto_rng_eio.ml
@@ -32,7 +32,7 @@ let periodically_feed_entropy env delta source =
     let idx = ref 0 in
     let f () =
       incr idx;
-      String.sub random (per_pool * (pred !idx)) per_pool
+      Ok (String.sub random (per_pool * (pred !idx)) per_pool)
     in
     Entropy.feed_pools None source f
   in

--- a/rng/lwt/mirage_crypto_rng_lwt.ml
+++ b/rng/lwt/mirage_crypto_rng_lwt.ml
@@ -19,7 +19,7 @@ let getrandom_task delta source =
     let idx = ref 0 in
     let f () =
       incr idx;
-      String.sub random (per_pool * (pred !idx)) per_pool
+      Ok (String.sub random (per_pool * (pred !idx)) per_pool)
     in
     Entropy.feed_pools None source f
   in

--- a/rng/miou/mirage_crypto_rng_miou_unix.ml
+++ b/rng/miou/mirage_crypto_rng_miou_unix.ml
@@ -18,7 +18,10 @@ let getrandom delta source =
     let size = per_pool * pools None in
     let random = Mirage_crypto_rng_unix.getrandom size in
     let idx = ref 0 in
-    let fn () = incr idx; String.sub random (per_pool * (pred !idx)) per_pool in
+    let fn () =
+      incr idx;
+      Ok (String.sub random (per_pool * (pred !idx)) per_pool)
+    in
     Entropy.feed_pools None source fn in
   periodic fn delta
 

--- a/rng/mirage_crypto_rng.mli
+++ b/rng/mirage_crypto_rng.mli
@@ -145,6 +145,18 @@ module Entropy : sig
       of [g]. It uses {!feed_pools} internally. If neither rdrand nor rdseed
       are available, [`Not_supported] is returned. *)
 
+  val rdrand_calls : unit -> int
+  (** [rdrand_calls ()] returns the number of rdrand calls. *)
+
+  val rdrand_failures : unit -> int
+  (** [rdrand_failures ()] returns the number of rdrand failures. *)
+
+  val rdseed_calls : unit -> int
+  (** [rdseed_calls ()] returns the number of rdseed calls. *)
+
+  val rdseed_failures : unit -> int
+  (** [rdseed_failures ()] returns the number of rdseed failures. *)
+
   (**/**)
   val id : source -> int
   (** [id source] is the identifier used for [source]. *)

--- a/rng/mirage_crypto_rng.mli
+++ b/rng/mirage_crypto_rng.mli
@@ -136,14 +136,14 @@ module Entropy : sig
 
   (** {1 Periodic pulled sources} *)
 
-  val feed_pools : g option -> source -> (unit -> string) -> unit
+  val feed_pools : g option -> source -> (unit -> (string, [ `No_random_available ]) result) -> unit
   (** [feed_pools g source f] feeds all pools of [g] using [source] by executing
       [f] for each pool. *)
 
   val cpu_rng : (g option -> unit -> unit, [`Not_supported]) Result.t
   (** [cpu_rng g] uses the CPU RNG (rdrand or rdseed) to feed all pools
       of [g]. It uses {!feed_pools} internally. If neither rdrand nor rdseed
-      are available, [fun () -> ()] is returned. *)
+      are available, [`Not_supported] is returned. *)
 
   (**/**)
   val id : source -> int

--- a/rng/mirage_crypto_rng.mli
+++ b/rng/mirage_crypto_rng.mli
@@ -114,11 +114,13 @@ module Entropy : sig
 
   val cpu_rng_bootstrap : (int -> string, [`Not_supported]) Result.t
   (** [cpu_rng_bootstrap id] returns 8 bytes of random data using the CPU
-      RNG (rdseed or rdrand). On 32bit platforms, only 4 bytes are filled.
-      The [id] is used as prefix.
+      RNG (rdseed). On 32bit platforms, only 4 bytes are filled.
+      The [id] is used as prefix. If only rdrand is available, the return
+      value is the concatenation of 512 calls to rdrand.
 
-      @raise Failure if no CPU RNG is available, or if it doesn't return a
-      random value. *)
+      @raise Failure if rdrand fails 512 times, or if rdseed fails and rdrand
+      is not available.
+  *)
 
   val bootstrap : int -> string
   (** [bootstrap id] is either [cpu_rng_bootstrap], if the CPU supports it, or

--- a/src/native/entropy_cpu_stubs.c
+++ b/src/native/entropy_cpu_stubs.c
@@ -241,7 +241,7 @@ CAMLprim value mc_cpu_rdseed (value buf, value off) {
   /* ARM: CPU-assisted randomness here. */
   (void)buf;
   (void)off;
-  return Val_bool (0);
+  return Val_false;
 #endif
 }
 
@@ -257,7 +257,7 @@ CAMLprim value mc_cpu_rdrand (value buf, value off) {
   /* ARM: CPU-assisted randomness here. */
   (void)buf;
   (void)off;
-  return Val_bool (0);
+  return Val_false;
 #endif
 }
 

--- a/src/native/entropy_cpu_stubs.c
+++ b/src/native/entropy_cpu_stubs.c
@@ -239,6 +239,8 @@ CAMLprim value mc_cpu_rdseed (value buf, value off) {
   return Val_bool (ok);
 #else
   /* ARM: CPU-assisted randomness here. */
+  (void)buf;
+  (void)off;
   return Val_bool (0);
 #endif
 }
@@ -253,6 +255,8 @@ CAMLprim value mc_cpu_rdrand (value buf, value off) {
   return Val_bool (ok);
 #else
   /* ARM: CPU-assisted randomness here. */
+  (void)buf;
+  (void)off;
   return Val_bool (0);
 #endif
 }

--- a/src/native/entropy_cpu_stubs.c
+++ b/src/native/entropy_cpu_stubs.c
@@ -15,27 +15,13 @@
 #define random_t unsigned long long
 #define _rdseed_step _rdseed64_step
 #define _rdrand_step _rdrand64_step
-#define fill_bytes(buf, off, data) {                    \
-    (_bp_uint8_off(buf, off))[0] = (uint8_t)((data) >> 56);     \
-    (_bp_uint8_off(buf, off))[1] = (uint8_t)((data) >> 48);     \
-    (_bp_uint8_off(buf, off))[2] = (uint8_t)((data) >> 40);     \
-    (_bp_uint8_off(buf, off))[3] = (uint8_t)((data) >> 32);     \
-    (_bp_uint8_off(buf, off))[4] = (uint8_t)((data) >> 24);     \
-    (_bp_uint8_off(buf, off))[5] = (uint8_t)((data) >> 16);     \
-    (_bp_uint8_off(buf, off))[6] = (uint8_t)((data) >> 8);      \
-    (_bp_uint8_off(buf, off))[7] = (uint8_t)((data));           \
-  }
+#define fill_bytes(buf, off, data) memcpy(_bp_uint8_off(buf, off), data, 8)
 
 #elif defined (__i386__)
 #define random_t unsigned int
 #define _rdseed_step _rdseed32_step
 #define _rdrand_step _rdrand32_step
-#define fill_bytes(buf, off, data) {                    \
-    (_bp_uint8_off(buf, off))[0] = (uint8_t)((data) >> 24);     \
-    (_bp_uint8_off(buf, off))[1] = (uint8_t)((data) >> 16);     \
-    (_bp_uint8_off(buf, off))[2] = (uint8_t)((data) >> 8);      \
-    (_bp_uint8_off(buf, off))[3] = (uint8_t)((data));           \
-  }
+#define fill_bytes(buf, off, data) memcpy(_bp_uint8_off(buf, off), data, 4)
 
 #endif
 #endif /* __i386__ || __x86_64__ */
@@ -251,7 +237,7 @@ CAMLprim value mc_cpu_rdseed (value buf, value off) {
   int ok = 0;
   int i = RETRIES;
   do { ok = _rdseed_step (&r); _mm_pause (); } while ( !(ok | !--i) );
-  fill_bytes(buf, off, r);
+  fill_bytes(buf, off, &r);
   return Val_bool (ok);
 #else
   /* ARM: CPU-assisted randomness here. */
@@ -265,7 +251,7 @@ CAMLprim value mc_cpu_rdrand (value buf, value off) {
   int ok = 0;
   int i = RETRIES;
   do { ok = _rdrand_step (&r); } while ( !(ok | !--i) );
-  fill_bytes(buf, off, r);
+  fill_bytes(buf, off, &r);
   return Val_bool (ok);
 #else
   /* ARM: CPU-assisted randomness here. */


### PR DESCRIPTION
- Previously, a return value of "0" was treated specially, but rdrand/rdseed may return 0!
- If there's a failure in rdrand/rdseed during cpu_rng_bootstrap, raise an exception
- If there's a failure during the periodic reseeding (timer initiated feeding of all pools), ignore it (for now!?)

//cc @edwintorok addresses #251 -- though I'm not yet happy with the `cpu_rng` failure case // `feed_pools` error case. I'm uncertain what to do:
- do a while true, potentially leading to a busy loop if rdrand/rdseed keeps on giving no data
- raise an exception and exit - which may be inconvenient for the application developer
- call rdseed/rdrand (the other instruction) as an attempt to delay the error condition