### PR TITLE
Fixes for the less common platforms

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+## Pending
+
+* Use arc4random_buf instead of getrandom on Android before getrandom
+  became available in API 28.
+
 ## v2.0.0 (2025-02-03)
 
 * Remove now superfluous mirage-crypto-rng-{eio,lwt,async} packages

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,8 @@
 ## Pending
 
 * Use arc4random_buf instead of getrandom on Android before getrandom
-  became available in API 28.
+  became available in API 28 (#259 @jonahbeckford)
+* Define fill_bytes for MSVC (#259 @jonahbeckford)
 
 ## v2.0.0 (2025-02-03)
 

--- a/rng/unix/mc_getrandom_stubs.c
+++ b/rng/unix/mc_getrandom_stubs.c
@@ -9,7 +9,14 @@
 #include <caml/unixsupport.h>
 #include <caml/bigarray.h>
 
-#if defined(__linux) || defined(__GNU__)
+#if defined(__ANDROID_API__) && __ANDROID_API__ < 28
+// on Android 27 and earlier, we use Google's <sys/random.h> recommended arc4random_buf
+# include <stdlib.h>
+
+void raw_getrandom (uint8_t *data, size_t len) {
+  arc4random_buf(data, len);
+}
+#elif defined(__linux) || defined(__GNU__)
 # include <errno.h>
 // on Linux and GNU/Hurd, we use getrandom and loop
 


### PR DESCRIPTION
Fixes the following:

1. Android 27 and earlier do not have `getrandom` but there is a recommended alternative. https://android.googlesource.com/platform/bionic/+/02ce401d1e2b31586c94c8b6999364bbbce27388/libc/include/sys/random.h
2. MSVC needed a definition for `fill_bytes`.
