### PR TITLE
Add a missing dependency in the configuration detection

### DIFF
--- a/config/dune
+++ b/config/dune
@@ -1,3 +1,8 @@
 (executables
  (names cfg)
  (libraries dune-configurator))
+
+(rule
+ (targets cflags.sexp cflags_optimized.sexp cflags_warn.sexp)
+ (action
+  (run ./cfg.exe)))

--- a/config/dune
+++ b/config/dune
@@ -4,5 +4,7 @@
 
 (rule
  (targets cflags.sexp cflags_optimized.sexp cflags_warn.sexp)
+ (deps
+  (glob_files %{workspace_root}/.dune/configurator*))
  (action
   (run ./cfg.exe)))

--- a/ec/dune
+++ b/ec/dune
@@ -9,15 +9,10 @@
   (include_dirs ../src/native)
   (flags
    (:standard -DNDEBUG)
-   (:include cflags_optimized.sexp))))
+   (:include ../config/cflags_optimized.sexp))))
 
 (env
  (dev
-  (c_flags (:include cflags_warn.sexp))))
+  (c_flags (:include ../config/cflags_warn.sexp))))
 
 (include_subdirs unqualified)
-
-(rule
- (targets cflags_optimized.sexp cflags_warn.sexp)
- (action
-  (run ../config/cfg.exe)))

--- a/rng/unix/dune
+++ b/rng/unix/dune
@@ -8,11 +8,6 @@
  (action
   (run ./discover.exe)))
 
-(rule
- (targets cflags_warn.sexp)
- (action
-  (run ../../config/cfg.exe)))
-
 (library
  (name mirage_crypto_rng_unix)
  (public_name mirage-crypto-rng.unix)
@@ -27,4 +22,4 @@
 
 (env
  (dev
-  (c_flags (:include cflags_warn.sexp))))
+  (c_flags (:include ../../config/cflags_warn.sexp))))

--- a/src/dune
+++ b/src/dune
@@ -11,21 +11,16 @@
     entropy_cpu_stubs)
   (flags
    (:standard)
-   (:include cflags_optimized.sexp)))
+   (:include ../config/cflags_optimized.sexp)))
  (foreign_stubs
   (language c)
   (names chacha_generic)
   (flags
    (:standard)
-   (:include cflags.sexp))))
+   (:include ../config/cflags.sexp))))
 
 (env
  (dev
-  (c_flags (:include cflags_warn.sexp))))
+  (c_flags (:include ../config/cflags_warn.sexp))))
 
 (include_subdirs unqualified)
-
-(rule
- (targets cflags.sexp cflags_optimized.sexp cflags_warn.sexp)
- (action
-  (run ../config/cfg.exe)))


### PR DESCRIPTION
This PR fixes an issue due to a missing dependency on the configuration for the configuration detection.

The configuration detection executable uses `dune-configurator` and so it uses the configuration passed in (currently) `.dune/configurator.v2` in particular to know which C compiler it should invoke. This adds an explicit dependency to this file (with a glob in case the format changes) to make sure a change of compiler triggers a redetection.

The issue arose when building a MirageOS unikernel with a Unikraft backend. The OCaml/Unikraft packaging makes it easy to switch between arm64 and x86_64 architecture, where only the `%{lib}%/findlib.conf.d/unikraft.conf` file is updated to point to one or the other toolchain. With such a change of target, `dune` was missing the dependency information to rerun `cfg.exe` with the proper C compiler.

This PR also takes the opportunity to centralise the detection in one directory.

The bug investigation is joint work with @Firobe.