### PR TITLE
Disable test_entropy for riscv 64

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -1,3 +1,3 @@
-(lang dune 2.7)
+(lang dune 3.2)
 (name mirage-crypto)
 (formatting disabled)

--- a/ec/gen_tables/gen_tables.ml
+++ b/ec/gen_tables/gen_tables.ml
@@ -98,7 +98,7 @@ let usage () =
        pp_print_string)
     (List.map fst curves)
 
-let go =
+let () =
   let name, curve, wordsize =
     try
       let name, curve =

--- a/ec/gen_tables/gen_tables.ml
+++ b/ec/gen_tables/gen_tables.ml
@@ -21,8 +21,6 @@ let pp_array elem_fmt fmt arr =
   done;
   fout "@]@,}"
 
-let div_round_up a b = (a / b) + if a mod b = 0 then 0 else 1
-
 let pp_string_words ~wordsize fmt str =
   assert (String.length str * 8 mod wordsize = 0);
   let limbs = String.length str * 8 / wordsize in

--- a/mirage-crypto-ec.opam
+++ b/mirage-crypto-ec.opam
@@ -26,7 +26,7 @@ homepage: "https://github.com/mirage/mirage-crypto"
 doc: "https://mirage.github.io/mirage-crypto/doc"
 bug-reports: "https://github.com/mirage/mirage-crypto/issues"
 depends: [
-  "dune" {>= "2.7"}
+  "dune" {>= "3.2"}
   "ocaml" {>= "4.13.0"}
   "dune-configurator"
   "eqaf" {>= "0.7"}

--- a/mirage-crypto-pk.opam
+++ b/mirage-crypto-pk.opam
@@ -15,7 +15,7 @@ build: [ ["dune" "subst"] {dev}
 depends: [
   "conf-gmp-powm-sec" {build}
   "ocaml" {>= "4.13.0"}
-  "dune" {>= "2.7"}
+  "dune" {>= "3.2"}
   "ounit2" {with-test}
   "randomconv" {with-test & >= "0.2.0"}
   "ohex" {with-test & >= "0.2.0"}

--- a/mirage-crypto-rng-miou-unix.opam
+++ b/mirage-crypto-rng-miou-unix.opam
@@ -14,7 +14,7 @@ build: [ ["dune" "subst"] {dev}
 
 depends: [
   "ocaml" {>= "5.0.0"}
-  "dune" {>= "2.7"}
+  "dune" {>= "3.2"}
   "miou" {>= "0.2.0"}
   "logs"
   "mirage-crypto-rng" {=version}

--- a/mirage-crypto-rng-mirage.opam
+++ b/mirage-crypto-rng-mirage.opam
@@ -14,7 +14,7 @@ build: [ ["dune" "subst"] {dev}
 
 depends: [
   "ocaml" {>= "4.13.0"}
-  "dune" {>= "2.7"}
+  "dune" {>= "3.2"}
   "mirage-crypto-rng" {=version}
   "duration"
   "logs"

--- a/mirage-crypto-rng-mkernel.opam
+++ b/mirage-crypto-rng-mkernel.opam
@@ -14,7 +14,7 @@ build: [ ["dune" "subst"] {dev}
 
 depends: [
   "ocaml" {>= "5.0.0"}
-  "dune" {>= "2.7"}
+  "dune" {>= "3.2"}
   "miou" {>= "0.2.0"}
   "logs"
   "mirage-crypto-rng" {=version}

--- a/mirage-crypto-rng.opam
+++ b/mirage-crypto-rng.opam
@@ -14,7 +14,7 @@ build: [ ["dune" "subst"] {dev}
 
 depends: [
   "ocaml" {>= "4.14.0"}
-  "dune" {>= "2.7"}
+  "dune" {>= "3.2"}
   "dune-configurator" {>= "2.0.0"}
   "duration"
   "logs"

--- a/mirage-crypto.opam
+++ b/mirage-crypto.opam
@@ -14,7 +14,7 @@ build: [ ["dune" "subst"] {dev}
 
 depends: [
   "ocaml" {>= "4.13.0"}
-  "dune" {>= "2.7"}
+  "dune" {>= "3.2"}
   "dune-configurator" {>= "2.0.0"}
   "ounit2" {with-test}
   "ohex" {with-test & >= "0.2.0"}

--- a/tests/dune
+++ b/tests/dune
@@ -35,7 +35,8 @@
  (modules test_entropy)
  (package mirage-crypto-rng)
  (libraries mirage-crypto-rng ohex)
- (enabled_if (and (<> %{architecture} "arm64") (<> %{architecture} "riscv64"))))
+ (enabled_if (and (<> %{architecture} "arm64")
+                  (not (and (= %{architecture} "riscv") %{arch_sixtyfour})))))
  ; see https://github.com/mirage/mirage-crypto/issues/216
 
 (test


### PR DESCRIPTION
This addresses #272.

There are unrelated fatal unused values warnings in `ec/gen_tables/gen_tables.ml` that make it fail. But `test_entropy` is not run on riscv 64 bit.