### PR TITLE
Skip entropy timer test on x86_64 macOS

### DIFF
--- a/tests/dune
+++ b/tests/dune
@@ -35,7 +35,12 @@
  (modules test_entropy)
  (package mirage-crypto-rng)
  (libraries mirage-crypto-rng ohex)
- (enabled_if (and (<> %{architecture} "arm64") (<> %{architecture} "riscv"))))
+ (enabled_if
+  (and
+   (<> %{architecture} "arm64")
+   (and
+    (<> %{architecture} "riscv")
+    (or (<> %{system} "macosx") (<> %{architecture} "amd64"))))))
  ; see https://github.com/mirage/mirage-crypto/issues/216
 
 (test


### PR DESCRIPTION
`test_entropy` can fail intermittently on x86_64 macOS because it expects consecutive cycle-counter samples to differ.
This updates the Dune `enabled_if` condition to skip that test on macOS `amd64`, matching the existing platform-specific skips for arm64 and riscv.