### PR TITLE
Re-add blinding for NIST elliptic curves (Dsa.sign)

### DIFF
--- a/bench/speed.ml
+++ b/bench/speed.ml
@@ -191,21 +191,21 @@ let ecdsa_p256 =
     (Mirage_crypto_ec.P256.Dsa.priv_of_octets
        "\x08\x9f\x4f\xfc\xcc\xf9\xba\x13\xfe\xdd\x09\x42\xef\x08\xcf\x2d\x90\x9f\x32\xe2\x93\x4a\xb5\xc9\x3b\x6c\x99\xbe\x5a\x9f\xf5\x27")
 
-let ecdsa_p256_sig () = Mirage_crypto_ec.P256.Dsa.sign ~key:ecdsa_p256 msg_str_32
+let ecdsa_p256_sig () = Mirage_crypto_ec.P256.Dsa.sign ~mask:`No ~key:ecdsa_p256 msg_str_32
 
 let ecdsa_p384 =
   Result.get_ok
     (Mirage_crypto_ec.P384.Dsa.priv_of_octets
        "\xf5\xc0\xc9\xfb\x95\x17\x86\x41\xaf\x76\xf3\x83\x1f\x41\xe2\xd3\x7c\xfa\xaf\xff\xc7\xe6\x01\x72\xcf\xb0\x89\xfe\x60\x4b\x56\xa6\x1c\x7c\x31\xa6\x90\x4b\x3b\x5d\x08\x20\x7a\x4b\x81\xe2\x5e\xa5")
 
-let ecdsa_p384_sig () = Mirage_crypto_ec.P384.Dsa.sign ~key:ecdsa_p384 msg_str_48
+let ecdsa_p384_sig () = Mirage_crypto_ec.P384.Dsa.sign ~mask:`No ~key:ecdsa_p384 msg_str_48
 
 let ecdsa_p521 =
   Result.get_ok
     (Mirage_crypto_ec.P521.Dsa.priv_of_octets
        "\x00\xb1\x8f\x60\xc0\x35\x2a\xd8\xe3\xef\x98\x2f\x1d\xdf\xcf\x6e\xec\x7f\xa6\xca\xf0\xe6\xf3\x68\x35\x4a\x8b\x02\xb2\xd8\xac\x1e\x05\x9e\x30\x98\x91\xe2\xbf\xa8\x57\x91\xa5\xe7\x1b\x40\xbd\xec\xbf\x90\x2b\xf2\x43\xdc\x3b\x00\x80\x49\x5c\xf4\xd9\x1c\x78\x72\x8b\xd5")
 
-let ecdsa_p521_sig () = Mirage_crypto_ec.P521.Dsa.sign ~key:ecdsa_p521 msg_str_65
+let ecdsa_p521_sig () = Mirage_crypto_ec.P521.Dsa.sign ~mask:`No ~key:ecdsa_p521 msg_str_65
 
 let ed25519 =
   Result.get_ok (Mirage_crypto_ec.Ed25519.priv_of_octets

--- a/ec/mirage_crypto_ec.ml
+++ b/ec/mirage_crypto_ec.ml
@@ -724,7 +724,7 @@ module Make_dsa (Param : Parameters) (F : Fn) (P : Point) (S : Scalar) (H : Dige
   let sign ?(mask = `Yes) ~key ?k msg =
     (* blinding: literature: s = k^-1 * (m + r * priv_key) mod n
        we blind, similar to OpenSSL (https://github.com/openssl/openssl/commit/a3e9d5aa980f238805970f420adf5e903d35bf09):
-       s = k^-1 * blind^-1 (blind * m + blind * r * priv_key) mod n
+       s = k^-1 * blind^-1 * (blind * m + blind * r * priv_key) mod n
     *)
     let b = blind mask in
     let msg = padded msg in

--- a/ec/mirage_crypto_ec.ml
+++ b/ec/mirage_crypto_ec.ml
@@ -698,23 +698,10 @@ module Make_dsa (Param : Parameters) (F : Fn) (P : Point) (S : Scalar) (H : Dige
     let q = S.scalar_mult_base d in
     (d, q)
 
-  let not_zero =
-    let zero = String.make Param.byte_length '\000' in
-    fun n -> not (String.equal zero n)
-
-  let mod_n v =
-    let v' = F.from_be_octets v in
-    let v' = F.mul v' F.one in
-    let v' = F.from_montgomery v' in
-    F.to_be_octets v'
-
-  let smaller_n v =
-    String.equal v (mod_n v)
-
   let blind mask =
     let rec rng g =
       let r = Mirage_crypto_rng.generate ?g Param.byte_length in
-      if not_zero r && smaller_n r then begin
+      if S.is_in_range r then begin
         let ba = F.from_be_octets r in
         Some (ba, F.inv ba)
       end else

--- a/ec/mirage_crypto_ec.ml
+++ b/ec/mirage_crypto_ec.ml
@@ -55,7 +55,8 @@ module type Dsa = sig
   val pub_to_octets : ?compress:bool -> pub -> string
   val pub_of_priv : priv -> pub
   val generate : ?g:Mirage_crypto_rng.g -> unit -> priv * pub
-  val sign : key:priv -> ?k:string -> string -> string * string
+  val sign : ?mask:[ `No | `Yes | `Yes_with of Mirage_crypto_rng.g ] ->
+    key:priv -> ?k:string -> string -> string * string
   val verify : key:pub -> string * string -> string -> bool
   module K_gen (H : Digestif.S) : sig
     val generate : key:priv -> string -> string
@@ -697,6 +698,33 @@ module Make_dsa (Param : Parameters) (F : Fn) (P : Point) (S : Scalar) (H : Dige
     let q = S.scalar_mult_base d in
     (d, q)
 
+  let not_zero =
+    let zero = String.make Param.byte_length '\000' in
+    fun n -> not (String.equal zero n)
+
+  let mod_n v =
+    let v' = F.from_be_octets v in
+    let v' = F.mul v' F.one in
+    let v' = F.from_montgomery v' in
+    F.to_be_octets v'
+
+  let smaller_n v =
+    String.equal v (mod_n v)
+
+  let blind mask =
+    let rec rng g =
+      let r = Mirage_crypto_rng.generate ?g Param.byte_length in
+      if not_zero r && smaller_n r then begin
+        let ba = F.from_be_octets r in
+        Some (ba, F.inv ba)
+      end else
+        rng g
+    in
+    match mask with
+    | `No -> None
+    | `Yes -> rng None
+    | `Yes_with g -> rng (Some g)
+
   let x_of_finite_point_mod_n p =
     match P.to_affine_raw p with
     | None -> None
@@ -706,7 +734,12 @@ module Make_dsa (Param : Parameters) (F : Fn) (P : Point) (S : Scalar) (H : Dige
       let x = F.from_montgomery x in
       Some (F.to_be_octets x)
 
-  let sign ~key ?k msg =
+  let sign ?(mask = `Yes) ~key ?k msg =
+    (* blinding: literature: s = k^-1 * (m + r * priv_key) mod n
+       we blind, similar to OpenSSL (https://github.com/openssl/openssl/commit/a3e9d5aa980f238805970f420adf5e903d35bf09):
+       s = k^-1 * blind^-1 (blind * m + blind * r * priv_key) mod n
+    *)
+    let b = blind mask in
     let msg = padded msg in
     let e = F.from_be_octets msg in
     let g = K_gen_default.g ~key msg in
@@ -729,9 +762,18 @@ module Make_dsa (Param : Parameters) (F : Fn) (P : Point) (S : Scalar) (H : Dige
         let kmon = F.from_be_octets k' in
         let kinv = F.inv kmon in
         let dmon = F.from_be_octets (S.to_octets key) in
+        let dmon =
+          match b with None -> dmon | Some (b, _) -> F.mul b dmon
+        in
         let rd = F.mul r_mon dmon in
+        let e =
+          match b with None -> e | Some (b, _) -> F.mul b e
+        in
         let cmon = F.add e rd in
         let smon = F.mul kinv cmon in
+        let smon =
+          match b with None -> smon | Some (_, b') -> F.mul b' smon
+        in
         let s = F.from_montgomery smon in
         let s = F.to_be_octets s in
         if S.not_zero s && S.not_zero r then

--- a/ec/mirage_crypto_ec.ml
+++ b/ec/mirage_crypto_ec.ml
@@ -701,10 +701,9 @@ module Make_dsa (Param : Parameters) (F : Fn) (P : Point) (S : Scalar) (H : Dige
   let blind mask =
     let rec rng g =
       let r = Mirage_crypto_rng.generate ?g Param.byte_length in
-      if S.is_in_range r then begin
-        let ba = F.from_be_octets r in
-        Some (ba, F.inv ba)
-      end else
+      if S.is_in_range r then
+        Some (F.from_be_octets r)
+      else
         rng g
     in
     match mask with
@@ -723,8 +722,7 @@ module Make_dsa (Param : Parameters) (F : Fn) (P : Point) (S : Scalar) (H : Dige
 
   let sign ?(mask = `Yes) ~key ?k msg =
     (* blinding: literature: s = k^-1 * (m + r * priv_key) mod n
-       we blind, similar to OpenSSL (https://github.com/openssl/openssl/commit/a3e9d5aa980f238805970f420adf5e903d35bf09):
-       s = k^-1 * blind^-1 * (blind * m + blind * r * priv_key) mod n
+       we blind: s = (k * blind)^-1 * (blind * m + blind * r * priv_key) mod n
     *)
     let b = blind mask in
     let msg = padded msg in
@@ -747,20 +745,20 @@ module Make_dsa (Param : Parameters) (F : Fn) (P : Point) (S : Scalar) (H : Dige
       | Some r ->
         let r_mon = F.from_be_octets r in
         let kmon = F.from_be_octets k' in
+        let kmon =
+          match b with None -> kmon | Some b -> F.mul b kmon
+        in
         let kinv = F.inv kmon in
         let dmon = F.from_be_octets (S.to_octets key) in
         let dmon =
-          match b with None -> dmon | Some (b, _) -> F.mul b dmon
+          match b with None -> dmon | Some b -> F.mul b dmon
         in
         let rd = F.mul r_mon dmon in
         let e =
-          match b with None -> e | Some (b, _) -> F.mul b e
+          match b with None -> e | Some b -> F.mul b e
         in
         let cmon = F.add e rd in
         let smon = F.mul kinv cmon in
-        let smon =
-          match b with None -> smon | Some (_, b') -> F.mul b' smon
-        in
         let s = F.from_montgomery smon in
         let s = F.to_be_octets s in
         if S.not_zero s && S.not_zero r then

--- a/ec/mirage_crypto_ec.mli
+++ b/ec/mirage_crypto_ec.mli
@@ -112,12 +112,14 @@ module type Dsa = sig
 
   (** {2 Cryptographic operations} *)
 
-  val sign : key:priv -> ?k:string -> string -> string * string
-  (** [sign ~key ~k digest] signs the message [digest] using the private
+  val sign : ?mask:[ `No | `Yes | `Yes_with of Mirage_crypto_rng.g ] ->
+    key:priv -> ?k:string -> string -> string * string
+  (** [sign ~mask ~key ~k digest] signs the message [digest] using the private
       [key]. The [digest] is not processed further - it should be the hash of
-      the message to sign. If [k] is not provided, it is computed using the
-      deterministic construction from RFC 6979. The result is a pair of [r]
-      and [s].
+      the message to sign. If [mask] is provided, the computation is blinded to
+      protect the private key operation. If [k] is not provided, it is computed
+      using the deterministic construction from RFC 6979. The result is a pair
+      of [r] and [s].
 
       Warning: there {{:https://www.hertzbleed.com/2h2b.pdf}are}
       {{:https://www.hertzbleed.com/hertzbleed.pdf}attacks} that recover the


### PR DESCRIPTION
Reverts "mirage-crypto-ec: remove blinding for sign"

This reverts commit 2cdea169560c4b4ff3351a087d93dbc028d7195b.

My measured performance impact is 10-15%. Is this reasonable?

//cc @edwintorok (of course others if they have opinions)