### PR TITLE
rng: remove a wrong [@@noalloc] on the getrandom binding

### DIFF
--- a/rng/unix/getentropy.ml
+++ b/rng/unix/getentropy.ml
@@ -1,5 +1,5 @@
 
-external getrandom_buf : bytes -> int -> int -> unit = "mc_getrandom" [@@noalloc]
+external getrandom_buf : bytes -> int -> int -> unit = "mc_getrandom"
 
 type g = unit
 

--- a/rng/unix/mirage_crypto_rng_unix.ml
+++ b/rng/unix/mirage_crypto_rng_unix.ml
@@ -17,7 +17,7 @@ let use_default () = use_getentropy ()
 let src = Logs.Src.create "mirage-crypto-rng.unix" ~doc:"Mirage crypto RNG Unix"
 module Log = (val Logs.src_log src : Logs.LOG)
 
-external getrandom_buf : bytes -> int -> int -> unit = "mc_getrandom" [@@noalloc]
+external getrandom_buf : bytes -> int -> int -> unit = "mc_getrandom"
 
 let getrandom_into buf ~off ~len =
   getrandom_buf buf off len


### PR DESCRIPTION
The C function can fail and raise, but the binding was marked `[@@noalloc]`, which is not right. Removing the annotation on both bindings.