### PR TITLE
rng: avoid a spurious zero-length getentropy call

### DIFF
--- a/rng/unix/mc_getrandom_stubs.c
+++ b/rng/unix/mc_getrandom_stubs.c
@@ -50,7 +50,7 @@ void raw_getrandom (uint8_t *data, size_t len) {
 
 void raw_getrandom (uint8_t *data, size_t len) {
   size_t rlen = 0;
-  for (size_t i = 0; i <= len; i += 256) {
+  for (size_t i = 0; i < len; i += 256) {
     rlen = MIN(256, len - i);
     if (getentropy(data + i, rlen) == -1) uerror("getentropy", Nothing);
   }


### PR DESCRIPTION
When the requested length is a multiple of 256, the loop makes one extra `getentropy(data + len, 0)` call (zero-length), so it does nothing, just an unnecessary syscall. Using `<` instead of `<=` skips it.