### PR TITLE
dsa: avoid a divide-by-zero when k is 0

### DIFF
--- a/pk/dsa.ml
+++ b/pk/dsa.ml
@@ -104,7 +104,7 @@ let sign_z ?(mask = `Yes) ?k:k0 ~key:({ p; q; gg; x; _ } as key) z =
     | Some k when Z.zero < k && k < q -> k
     | Some _ -> invalid_arg "k not in range ]0, q["
     | None -> K_gen_sha256.z_gen ~key z
-    in
+  in
   let k' = Z.invert k q
   and b, b' = match expand_mask mask with
     | `No -> Z.one, Z.one

--- a/pk/dsa.ml
+++ b/pk/dsa.ml
@@ -100,7 +100,10 @@ end
 module K_gen_sha256 = K_gen (Digestif.SHA256)
 
 let sign_z ?(mask = `Yes) ?k:k0 ~key:({ p; q; gg; x; _ } as key) z =
-  let k = match k0 with Some k -> k | None -> K_gen_sha256.z_gen ~key z in
+  let k = match k0 with
+    | Some k when Z.zero < k && k < q -> k
+    | Some _ -> invalid_arg "k not in range ]0, q["
+    | None -> K_gen_sha256.z_gen ~key z in
   let k' = Z.invert k q
   and b, b' = match expand_mask mask with
     | `No -> Z.one, Z.one

--- a/pk/dsa.ml
+++ b/pk/dsa.ml
@@ -103,7 +103,8 @@ let sign_z ?(mask = `Yes) ?k:k0 ~key:({ p; q; gg; x; _ } as key) z =
   let k = match k0 with
     | Some k when Z.zero < k && k < q -> k
     | Some _ -> invalid_arg "k not in range ]0, q["
-    | None -> K_gen_sha256.z_gen ~key z in
+    | None -> K_gen_sha256.z_gen ~key z
+    in
   let k' = Z.invert k q
   and b, b' = match expand_mask mask with
     | `No -> Z.one, Z.one


### PR DESCRIPTION
Passing `k = 0` to `sign` ended up dividing by zero. Added a small check so it returns a clear error instead of a confusing exception.