### PR TITLE
CCM: avoid padding aligned associated data

### DIFF
--- a/src/ccm.ml
+++ b/src/ccm.ml
@@ -41,7 +41,7 @@ let gen_adata a =
   in
   let to_pad =
     let leftover = (llen + String.length a) mod block_size in
-    block_size - leftover
+    if leftover = 0 then 0 else block_size - leftover
   in
   llen + String.length a + to_pad,
   fun buf off ->

--- a/tests/test_cipher.ml
+++ b/tests/test_cipher.ml
@@ -459,6 +459,16 @@ let ccm_regressions =
     match authenticate_decrypt ~key ~nonce ~adata cipher with
     | Some x -> assert_oct_equal ~msg:"CCM decrypt of empty message" p x
     | None -> assert_failure "decryption broken"
+  and aligned_adata _ =
+    (* The two-byte length and 14-byte adata fill one block. *)
+    let key = of_secret (vx "000102030405060708090a0b0c0d0e0f")
+    and nonce = vx "000102030405060708090a0b0c"
+    and plaintext = ""
+    and adata = vx "000102030405060708090a0b0c0d"
+    and expected = vx "4c8deb839f1db3856356fe0c0956db30"
+    in
+    let cipher = authenticate_encrypt ~adata ~key ~nonce plaintext in
+    assert_oct_equal ~msg:"CCM encrypt with aligned adata" expected cipher
   and long_adata _ =
     let key = of_secret (vx "000102030405060708090a0b0c0d0e0f")
     and nonce = vx "0001020304050607"
@@ -629,6 +639,7 @@ b8fc 10f3 13c7 aa16  8165 a29c 67f1 46f4
     test_case short_nonce_enc3 ;
     test_case long_nonce_enc ;
     test_case enc_dec_empty_message ;
+    test_case aligned_adata ;
     test_case long_adata ;
   ] @ List.map test_case regr_tls
 


### PR DESCRIPTION
CCM currently appends a zero block when the encoded AAD already ends on a block boundary. This changes the tag, for example when a 14-byte AAD follows its two-byte length prefix. This patch adds no padding in that case and includes a known-answer test.

Verify the expected tag with:

```bash
python3 -m pip install cryptography
python3 - <<'PY'
from cryptography.hazmat.primitives.ciphers.aead import AESCCM
key = bytes.fromhex("000102030405060708090a0b0c0d0e0f")
nonce = bytes.fromhex("000102030405060708090a0b0c")
aad = bytes.fromhex("000102030405060708090a0b0c0d")
print(AESCCM(key, tag_length=16).encrypt(nonce, b"", aad).hex())
PY
```

Expected: `4c8deb839f1db3856356fe0c0956db30`