### PR TITLE
mirage-crypto-rng-mkernel: when the RNG is initialized, seed Stdlib.Random

### DIFF
--- a/rng/miou/mirage_crypto_rng_mkernel.ml
+++ b/rng/miou/mirage_crypto_rng_mkernel.ml
@@ -52,6 +52,12 @@ let initialize (type a) ?g ?(sleep= _1s) (rng : a generator) =
       with No_default_generator -> () in
     let rng = create ?g ~seed ~time:now rng in
     set_default_generator rng;
+    let seed =
+      Array.init 4 (fun _ ->
+          let r = Mirage_crypto_rng.generate 8 in
+          Int64.to_int (String.get_int64_be r 0))
+    in
+    Random.full_init seed;
     let hook = Mkernel.Hook.add (Entropy.timer_accumulator None) in
     (hook, rdrand sleep)
   end else invalid_arg miou_generator_already_launched


### PR DESCRIPTION
cc @dinosaure @reynir 