### PR TITLE
RSA.OAEP: reject encodings without a separator

### DIFF
--- a/pk/rsa.ml
+++ b/pk/rsa.ml
@@ -342,7 +342,7 @@ module OAEP (H : Digestif.S) = struct
     and mdb = String.sub msg (1 + hlen) (String.length msg - 1 - hlen)
     in
     let db = Bytes.unsafe_to_string (MGF.mask ~seed:(Bytes.unsafe_to_string (MGF.mask ~seed:mdb ms)) mdb) in
-    let i  = ct_find_uint8 ~default:0 ~off:hlen ~f:((<>) 0x00) db in
+    let i  = ct_find_uint8 ~default:hlen ~off:hlen ~f:((<>) 0x00) db in
     let c1 = Eqaf.equal (String.sub db 0 hlen) H.(digest_string label |> to_raw_string)
     and c2 = String.get_uint8 b0 0 = 0x00
     and c3 = String.get_uint8 db i = 0x01 in

--- a/tests/test_rsa.ml
+++ b/tests/test_rsa.ml
@@ -172,6 +172,23 @@ let rsa_oaep_encrypt_selftest ~bits n =
      | None     -> assert_failure "unpad failure"
      | Some dec -> assert_oct_equal msg dec ~msg:"recovery failure")
 
+let rsa_oaep_missing_separator _ =
+  let module OAEP_SHA1 = Rsa.OAEP (Digestif.SHA1) in
+  let key = gen_rsa ~bits:512
+  and label = "oaep-separator-regression-19"
+  (* Zero-seed OAEP encoding whose DB omits the 0x01 separator. *)
+  and encoded =
+    vx
+      "00175f6e4d5f89042fa4b90433ac7dff9e60eb6b50d29cf23daa66ca65f6cd7\
+       977924f87190712b5f6a4fa647defa221e1f720c856fd893973d239d2273c97f1"
+  in
+  let label_hash = Digestif.SHA1.(digest_string label |> to_raw_string) in
+  assert_equal 0x01 (String.get_uint8 label_hash 0);
+  let ciphertext = Rsa.(encrypt ~key:(pub_of_priv key) encoded) in
+  match OAEP_SHA1.decrypt ~mask:`No ~label ~key ciphertext with
+  | None -> ()
+  | Some _ -> assert_failure "accepted OAEP DB without separator"
+
 let rsa_pss_sign_selftest ~bits n =
   let module Pss_sha1 = Rsa.PSS (Digestif.SHA1) in
   "selftest" >:: times ~n @@ fun _ ->
@@ -319,6 +336,7 @@ let suite = [
   ] ;
 
   "RSA-regression" >::: [
+    test_case rsa_oaep_missing_separator ;
     test_case rsa_priv_of_primes_regression ;
     test_case rsa_priv_of_primes_regression_62 ;
     test_case rsa_priv_of_primes_regression_openssl ;


### PR DESCRIPTION
_(Note: I'm not a cryptographer and this was LLM-assisted. Please check my work!)_

RSA-OAEP encodes a message as:

```text
H(label) || zero padding || 0x01 || message
```

During decryption, the first nonzero byte after `H(label)` must therefore be the `0x01` separator. An encoding without that separator is invalid.

When the search found no nonzero byte, the decoder used to fall back to offset zero. If `H(label).[0]` happened to equal `0x01`, a separator-free encoding passed validation.

I think this should fall back to `hlen` instead. A failed search guarantees that this byte is zero, so the separator check fails, and this should continue to be a constant-time search.

The regression test uses a label whose SHA-1 digest starts with `0x01` and a deterministic OAEP block without a separator.