### PR TITLE
mirage-crypto-rng.unix: avoid duplicate output after fork

### DIFF
--- a/rng/unix/dune
+++ b/rng/unix/dune
@@ -17,7 +17,7 @@
  (name mirage_crypto_rng_unix)
  (public_name mirage-crypto-rng.unix)
  (modules mirage_crypto_rng_unix urandom getentropy)
- (libraries mirage-crypto-rng unix logs threads.posix)
+ (libraries mirage-crypto-rng unix logs)
  (foreign_stubs
   (language c)
   (include_dirs ../../src/native)

--- a/rng/unix/urandom.ml
+++ b/rng/unix/urandom.ml
@@ -1,4 +1,3 @@
-
 type g = Unix.file_descr
 
 let block = 1
@@ -10,17 +9,14 @@ let create ?time:_ () =
   at_exit (fun () -> Unix.close fd);
   fd
 
-let rec really_read fd buf ~off len =
+let rec generate_into ~g buf ~off len =
   if len > 0 then
     try
-      let n = Unix.read fd buf off len in
+      let n = Unix.read g buf off len in
       if n = 0 then failwith "couldn't read enough bytes from /dev/urandom"
-      else really_read fd buf ~off:(off + n) (len - n)
+      else generate_into ~g buf ~off:(off + n) (len - n)
     with
-    | Unix.Unix_error (Unix.EINTR, _, _) -> really_read fd buf ~off len
-
-let generate_into ~g buf ~off len =
-  really_read g buf ~off len
+    | Unix.Unix_error (Unix.EINTR, _, _) -> generate_into ~g buf ~off len
 
 let reseed ~g:_ _data = ()
 

--- a/rng/unix/urandom.ml
+++ b/rng/unix/urandom.ml
@@ -1,23 +1,26 @@
 
-type g = In_channel.t * Mutex.t
+type g = Unix.file_descr
 
-(* The OCaml runtime always reads at least IO_BUFFER_SIZE from an input channel, which is currently 64 KiB *)
-let block = 65536
+let block = 1
 
 let create ?time:_ () =
-  let ic = In_channel.open_bin "/dev/urandom"
-  and mutex = Mutex.create ()
+  let fd =
+    Unix.openfile "/dev/urandom" [ Unix.O_RDONLY; Unix.O_CLOEXEC ] 0
   in
-  at_exit (fun () -> In_channel.close ic);
-  (ic, mutex)
+  at_exit (fun () -> Unix.close fd);
+  fd
 
-let generate_into ~g:(ic, m) buf ~off len =
-  let finally () = Mutex.unlock m in
-  Mutex.lock m;
-  Fun.protect ~finally (fun () ->
-      match In_channel.really_input ic buf off len with
-      | None -> failwith "couldn't read enough bytes from /dev/urandom"
-      | Some () -> ())
+let rec really_read fd buf ~off len =
+  if len > 0 then
+    try
+      let n = Unix.read fd buf off len in
+      if n = 0 then failwith "couldn't read enough bytes from /dev/urandom"
+      else really_read fd buf ~off:(off + n) (len - n)
+    with
+    | Unix.Unix_error (Unix.EINTR, _, _) -> really_read fd buf ~off len
+
+let generate_into ~g buf ~off len =
+  really_read g buf ~off len
 
 let reseed ~g:_ _data = ()
 

--- a/tests/dune
+++ b/tests/dune
@@ -18,6 +18,13 @@
  (modules test_random_runner))
 
 (test
+ (name test_urandom_fork)
+ (modules test_urandom_fork)
+ (libraries mirage-crypto-rng mirage-crypto-rng.unix ounit2 unix)
+ (package mirage-crypto-rng)
+ (enabled_if (<> %{os_type} "Win32")))
+
+(test
  (name test_pk_runner)
  (libraries test_common mirage-crypto-pk mirage-crypto-rng.unix randomconv
    ounit2)

--- a/tests/test_urandom_fork.ml
+++ b/tests/test_urandom_fork.ml
@@ -1,0 +1,40 @@
+open OUnit2
+
+let output_length = 32
+
+let fork_safety _ =
+  Mirage_crypto_rng_unix.use_dev_urandom ();
+  ignore (Mirage_crypto_rng.generate 1);
+  let input, output = Unix.pipe () in
+  match Unix.fork () with
+  | 0 ->
+    Unix.close input;
+    (try
+       let output_channel = Unix.out_channel_of_descr output in
+       Out_channel.output_string output_channel
+         (Mirage_crypto_rng.generate output_length);
+       Out_channel.close output_channel;
+       Unix._exit 0
+     with _ -> Unix._exit 1)
+  | pid ->
+    Unix.close output;
+    let input_channel = Unix.in_channel_of_descr input in
+    let child_output =
+      In_channel.really_input_string input_channel output_length
+    in
+    In_channel.close input_channel;
+    let _, status = Unix.waitpid [] pid in
+    (match status with
+     | Unix.WEXITED 0 -> ()
+     | _ -> assert_failure "child process failed");
+    let child_output =
+      match child_output with
+      | Some output -> output
+      | None -> assert_failure "child process returned too few random bytes"
+    in
+    let parent_output = Mirage_crypto_rng.generate output_length in
+    assert_bool "parent and child returned the same random bytes"
+      (parent_output <> child_output)
+
+let () =
+  run_test_tt_main ("urandom" >::: [ "fork safety" >:: fork_safety ])


### PR DESCRIPTION
`Urandom` currently reads through an `In_channel`, which retains up to 64 KiB of random data in userspace. If the process forks after a read, parent and child inherit identical unread bytes and can return the same random output.

I think it's safer to read directly from the `/dev/urandom` descriptor instead. This preserves thread safety without copying random data across forks.

The regression test primes the generator, forks, and compares output from both processes.