### PR TITLE
rng: reuse registered entropy sources

### DIFF
--- a/rng/entropy.ml
+++ b/rng/entropy.ml
@@ -67,10 +67,13 @@ let register_source name =
     let sources = Atomic.get _sources in
     let n = S.cardinal sources in
     let source = (n, name) in
-    if Atomic.compare_and_set _sources sources (S.add source sources) then
-      source
-    else
-      set ()
+    match S.find_opt source sources with
+    | Some source -> source
+    | None ->
+      if Atomic.compare_and_set _sources sources (S.add source sources) then
+        source
+      else
+        set ()
   in
   set ()
 

--- a/tests/test_random_runner.ml
+++ b/tests/test_random_runner.ml
@@ -87,8 +87,22 @@ let xor_selftest n =
     assert_oct_equal ~msg:"invert" x x1 ;
     assert_oct_equal ~msg:"commut" x1 x2
 
+let entropy_source_registration =
+  "registration" >:: fun _ ->
+  let a = Mirage_crypto_rng.Entropy.register_source "test-source-a" in
+  let a' = Mirage_crypto_rng.Entropy.register_source "test-source-a" in
+  let b = Mirage_crypto_rng.Entropy.register_source "test-source-b" in
+  assert_equal
+    ~printer:string_of_int
+    (Mirage_crypto_rng.Entropy.id a)
+    (Mirage_crypto_rng.Entropy.id a');
+  assert_bool
+    "distinct sources have distinct IDs"
+    (Mirage_crypto_rng.Entropy.id a <> Mirage_crypto_rng.Entropy.id b)
+
 let suite =
   "All" >::: [
+    "entropy source" >::: [ entropy_source_registration ] ;
     "XOR" >::: [ xor_selftest 300 ] ;
     "3DES-ECB" >::: [ ecb_selftest (module DES.ECB) 100 ] ;
 


### PR DESCRIPTION
Entropy samples carry a numeric source ID so Fortuna can distinguish their origins.

The source set compares entries by name. Registering an existing name therefore left the set unchanged but returned a new ID equal to the set’s size. The next distinct source received the same ID.

Return the existing source for duplicate registrations. New registrations continue to use the atomic compare-and-set loop.