### PR TITLE
CCM: reject messages that do not fit in the length field

### DIFF
--- a/src/ccm.ml
+++ b/src/ccm.ml
@@ -2,6 +2,17 @@ open Uncommon
 
 let block_size = 16
 
+let valid_nonce nonce =
+  let nsize = String.length nonce in
+  if nsize < 7 || nsize > 13 then
+    invalid_arg "CCM: nonce length not between 7 and 13: %u" nsize
+
+let valid_message_length nonce len =
+  let l = 15 - String.length nonce in
+  let bits = 8 * l in
+  if bits < Sys.int_size && len >= 1 lsl bits then
+    invalid_arg "CCM: message length %u does not fit in %u bytes" len l
+
 let flags bit6 len1 len2 =
   bit6 lsl 6 + len1 lsl 3 + len2
 
@@ -75,6 +86,8 @@ let prepare_header nonce adata plen tlen =
 type mode = Encrypt | Decrypt
 
 let crypto_core_into ~cipher ~mode ~key ~nonce ~adata src ~src_off dst ~dst_off len =
+  valid_nonce nonce;
+  valid_message_length nonce len;
   let cbcheader = prepare_header nonce adata len block_size in
 
   let small_q = 15 - String.length nonce in

--- a/src/cipher_block.ml
+++ b/src/cipher_block.ml
@@ -476,20 +476,13 @@ module Modes = struct
       Ccm.unsafe_generation_encryption_into ~cipher ~key ~nonce ~adata
         src ~src_off dst ~dst_off ~tag_off len
 
-    let valid_nonce nonce =
-      let nsize = String.length nonce in
-      if nsize < 7 || nsize > 13 then
-        invalid_arg "CCM: nonce length not between 7 and 13: %u" nsize
-
     let authenticate_encrypt_into ~key ~nonce ?adata src ~src_off dst ~dst_off ~tag_off len =
       check_offset ~tag:"CCM" ~buf:"src" ~off:src_off ~len (String.length src);
       check_offset ~tag:"CCM" ~buf:"dst" ~off:dst_off ~len (Bytes.length dst);
       check_offset ~tag:"CCM" ~buf:"dst tag" ~off:tag_off ~len:tag_size (Bytes.length dst);
-      valid_nonce nonce;
       unsafe_authenticate_encrypt_into ~key ~nonce ?adata src ~src_off dst ~dst_off ~tag_off len
 
     let authenticate_encrypt ~key ~nonce ?adata cs =
-      valid_nonce nonce;
       let l = String.length cs in
       let dst = Bytes.create (l + tag_size) in
       unsafe_authenticate_encrypt_into ~key ~nonce ?adata cs ~src_off:0 dst ~dst_off:0 ~tag_off:l l;
@@ -506,7 +499,6 @@ module Modes = struct
       check_offset ~tag:"CCM" ~buf:"src" ~off:src_off ~len (String.length src);
       check_offset ~tag:"CCM" ~buf:"src tag" ~off:tag_off ~len:tag_size (String.length src);
       check_offset ~tag:"CCM" ~buf:"dst" ~off:dst_off ~len (Bytes.length dst);
-      valid_nonce nonce;
       unsafe_authenticate_decrypt_into ~key ~nonce ?adata src ~src_off ~tag_off dst ~dst_off len
 
     let authenticate_decrypt ~key ~nonce ?adata data =

--- a/tests/test_cipher.ml
+++ b/tests/test_cipher.ml
@@ -448,6 +448,32 @@ let ccm_regressions =
     assert_raises ~msg:"CCM with short nonce raises"
       (Invalid_argument "Mirage_crypto: CCM: nonce length not between 7 and 13: 14")
       (fun () -> authenticate_encrypt ~key ~nonce plaintext)
+  and long_message _ =
+    let key = of_secret (vx "000102030405060708090a0b0c0d0e0f")
+    and nonce = String.make 13 '\x00'
+    and plaintext = String.make (1 lsl 16) '\x00'
+    in
+    let exn =
+      Invalid_argument "Mirage_crypto: CCM: message length 65536 does not fit in 2 bytes"
+    in
+    assert_raises ~msg:"CCM encrypt of too long message raises" exn
+      (fun () -> authenticate_encrypt ~key ~nonce plaintext);
+    let dst = Bytes.create (String.length plaintext + tag_size) in
+    assert_raises ~msg:"CCM encrypt_into of too long message raises" exn
+      (fun () -> authenticate_encrypt_into ~key ~nonce plaintext ~src_off:0
+          dst ~dst_off:0 ~tag_off:(String.length plaintext) (String.length plaintext));
+    let ciphertext = plaintext ^ String.make tag_size '\x00' in
+    assert_raises ~msg:"CCM decrypt of too long message raises" exn
+      (fun () -> authenticate_decrypt ~key ~nonce ciphertext);
+    assert_raises ~msg:"CCM decrypt_into of too long message raises" exn
+      (fun () -> authenticate_decrypt_into ~key ~nonce ciphertext ~src_off:0
+          ~tag_off:(String.length plaintext) dst ~dst_off:0 (String.length plaintext));
+    assert_raises ~msg:"CCM unsafe_encrypt_into of too long message raises" exn
+      (fun () -> unsafe_authenticate_encrypt_into ~key ~nonce plaintext ~src_off:0
+          dst ~dst_off:0 ~tag_off:(String.length plaintext) (String.length plaintext));
+    assert_raises ~msg:"CCM unsafe_decrypt_into of too long message raises" exn
+      (fun () -> unsafe_authenticate_decrypt_into ~key ~nonce ciphertext ~src_off:0
+          ~tag_off:(String.length plaintext) dst ~dst_off:0 (String.length plaintext))
   and enc_dec_empty_message _ =
     (* as reported in https://github.com/mirleft/ocaml-nocrypto/issues/168 *)
     let key = of_secret (vx "000102030405060708090a0b0c0d0e0f")
@@ -628,6 +654,7 @@ b8fc 10f3 13c7 aa16  8165 a29c 67f1 46f4
     test_case short_nonce_enc2 ;
     test_case short_nonce_enc3 ;
     test_case long_nonce_enc ;
+    test_case long_message ;
     test_case enc_dec_empty_message ;
     test_case long_adata ;
   ] @ List.map test_case regr_tls


### PR DESCRIPTION
CCM sets $L = 15 - \lvert nonce\rvert$ and encodes the message length in $L$ bytes. Larger lengths are currently truncated. With a 13-byte nonce, for example, 65,536 bytes is encoded as length zero.

This change validates the nonce and message length in the shared CCM core before processing any data. This should exhaustively cover all safe and unsafe encrypt/decrypt entry points.

The regression test exercises a 13-byte nonce and a 65,536-byte message.