### PR TITLE
Reject wrapping stream cipher counters

### DIFF
--- a/src/chacha20.ml
+++ b/src/chacha20.ml
@@ -11,7 +11,7 @@ let of_secret a = a
 let chacha20_block state idx key_stream =
   Native.Chacha.round 10 state key_stream idx
 
-let init ctr ~key ~nonce =
+let init ctr ~key ~nonce ~blocks =
   let ctr_off = 48 in
   let set_ctr32 b v = Bytes.set_int32_le b ctr_off v
   and set_ctr64 b v = Bytes.set_int64_le b ctr_off v
@@ -19,16 +19,24 @@ let init ctr ~key ~nonce =
   let inc32 b = set_ctr32 b (Int32.add (Bytes.get_int32_le b ctr_off) 1l)
   and inc64 b = set_ctr64 b (Int64.add (Bytes.get_int64_le b ctr_off) 1L)
   in
+  let check_counter max =
+    if blocks > 0
+       && Int64.unsigned_compare (Int64.of_int (blocks - 1)) (Int64.sub max ctr) > 0
+    then invalid_arg "Chacha20: counter wrapped"
+  in
   let s, key, init_ctr, nonce_off, inc =
     match String.length key, String.length nonce, Int64.shift_right ctr 32 = 0L with
     | 32, 12, true ->
+      check_counter 0xffffffffL;
       let ctr = Int64.to_int32 ctr in
       "expand 32-byte k", key, (fun b -> set_ctr32 b ctr), 52, inc32
     | 32, 12, false ->
       invalid_arg "Counter too big for IETF mode (32 bit counter)"
     | 32, 8, _ ->
+      check_counter Int64.minus_one;
       "expand 32-byte k", key, (fun b -> set_ctr64 b ctr), 56, inc64
     | 16, 8, _ ->
+      check_counter Int64.minus_one;
       let k = key ^ key in
       "expand 16-byte k", k, (fun b -> set_ctr64 b ctr), 56, inc64
     | _ -> invalid_arg "Valid parameters are nonce 12 bytes and key 32 bytes \
@@ -43,8 +51,8 @@ let init ctr ~key ~nonce =
   state, inc
 
 let crypt_into ~key ~nonce ~ctr src ~src_off dst ~dst_off len =
-  let state, inc = init ctr ~key ~nonce in
   let block_count = len // block in
+  let state, inc = init ctr ~key ~nonce ~blocks:block_count in
   let last_len =
     let last = len mod block in
     if last = 0 then block else last

--- a/src/cipher_block.ml
+++ b/src/cipher_block.ml
@@ -105,10 +105,16 @@ module Block = struct
 end
 
 module Counters = struct
+  let wrapped () = invalid_arg "CTR: counter wrapped"
+
+  let check_count add ctr blocks =
+    if blocks > 0 then ignore (add ctr (Int64.of_int (blocks - 1)))
+
   module type S = sig
     type ctr
     val size : int
     val add  : ctr -> int64 -> ctr
+    val check : ctr -> int -> unit
     val of_octets : string -> ctr
     val unsafe_count_into : ctr -> bytes -> off:int -> blocks:int -> unit
   end
@@ -117,7 +123,11 @@ module Counters = struct
     type ctr = int64
     let size = 8
     let of_octets cs = String.get_int64_be cs 0
-    let add = Int64.add
+    let add t n =
+      let t' = Int64.add t n in
+      if Int64.unsigned_compare t' t < 0 then wrapped ();
+      t'
+    let check = check_count add
     let unsafe_count_into t buf ~off ~blocks =
       let ctr = Bytes.create 8 in
       Bytes.set_int64_be ctr 0 t;
@@ -131,9 +141,11 @@ module Counters = struct
       let buf = Bytes.unsafe_of_string cs in
       Bytes.(get_int64_be buf 0, get_int64_be buf 8)
     let add (w1, w0) n =
-      let w0'  = Int64.add w0 n in
-      let flip = if Int64.logxor w0 w0' < 0L then w0' > w0 else w0' < w0 in
-      ((if flip then Int64.succ w1 else w1), w0')
+      let w0' = Int64.add w0 n in
+      let carry = Int64.unsigned_compare w0' w0 < 0 in
+      if carry && w1 = -1L then wrapped ();
+      ((if carry then Int64.succ w1 else w1), w0')
+    let check = check_count add
     let unsafe_count_into (w1, w0) buf ~off ~blocks =
       let ctr = Bytes.create 16 in
       Bytes.set_int64_be ctr 0 w1; Bytes.set_int64_be ctr 8 w0;
@@ -145,6 +157,8 @@ module Counters = struct
     let add (w1, w0) n =
       let hi = 0xffffffff00000000L and lo = 0x00000000ffffffffL in
       (w1, Int64.(logor (logand hi w0) (add n w0 |> logand lo)))
+    let check _ blocks =
+      if Int64.of_int blocks > 0xfffffffeL then wrapped ()
     let unsafe_count_into (w1, w0) buf ~off ~blocks =
       let ctr = Bytes.create 16 in
       Bytes.set_int64_be ctr 0 w1; Bytes.set_int64_be ctr 8 w0;
@@ -291,9 +305,10 @@ module Modes = struct
 
     let unsafe_stream_into ~key ~ctr buf ~off len =
       let blocks = imax 0 len / block_size in
+      let slack = imax 0 len mod block_size in
+      Ctr.check ctr (blocks + if slack = 0 then 0 else 1);
       Ctr.unsafe_count_into ctr buf ~off ~blocks ;
       Core.encrypt ~key ~blocks (Bytes.unsafe_to_string buf) off buf off ;
-      let slack = imax 0 len mod block_size in
       if slack <> 0 then begin
         let buf' = Bytes.create block_size in
         let ctr = Ctr.add ctr (Int64.of_int blocks) in

--- a/src/mirage_crypto.mli
+++ b/src/mirage_crypto.mli
@@ -409,7 +409,9 @@ end
     type ctr
 
     val add_ctr : ctr -> int64 -> ctr
-    (** [add_ctr ctr n] adds [n] to [ctr]. *)
+    (** [add_ctr ctr n] adds the unsigned 64-bit value [n] to [ctr].
+
+        @raise Invalid_argument if the counter wraps. *)
 
     val next_ctr : ?off:int -> string -> ctr:ctr -> ctr
     (** [next_ctr ~off msg ~ctr] is the state of the counter after encrypting or
@@ -424,7 +426,7 @@ end
 {[encrypt ~ctr msg1 || encrypt ~ctr:(next_ctr ~ctr msg1) msg2
   == encrypt ~ctr (msg1 || msg2)]}
 
-    *)
+        @raise Invalid_argument if the counter wraps. *)
 
     val ctr_of_octets : string -> ctr
     (** [ctr_of_octets buf] converts the value of [buf] into a counter. *)
@@ -443,7 +445,9 @@ end
   == stream ~key ~ctr (k * block_size + x)]}
 
         In other words, it is possible to restart a keystream at [block_size]
-        boundaries by manipulating the counter. *)
+        boundaries by manipulating the counter.
+
+        @raise Invalid_argument if the counter wraps. *)
 
     val encrypt : key:key -> ctr:ctr -> string -> string
     (** [encrypt ~key ~ctr msg] is
@@ -456,7 +460,7 @@ end
     (** [stream_into ~key ~ctr dst ~off len] is the raw key stream put into
         [dst] starting at [off].
 
-        @raise Invalid_argument if [Bytes.length dst - off < len]. *)
+        @raise Invalid_argument if [Bytes.length dst - off < len] or the counter wraps. *)
 
     val encrypt_into : key:key -> ctr:ctr -> string -> src_off:int ->
       bytes -> dst_off:int -> int -> unit
@@ -465,7 +469,8 @@ end
         [src_off].
 
         @raise Invalid_argument if [dst_off < 0 || Bytes.length dst - dst_off < len].
-        @raise Invalid_argument if [src_off < 0 || String.length src - src_off < len]. *)
+        @raise Invalid_argument if [src_off < 0 || String.length src - src_off < len].
+        @raise Invalid_argument if the counter wraps. *)
 
     val decrypt_into : key:key -> ctr:ctr -> string -> src_off:int ->
       bytes -> dst_off:int -> int -> unit
@@ -550,10 +555,10 @@ module Chacha20 : sig
       the counter is 8 byte, same as the nonce) and the IETF RFC 8439
       specification (where nonce is 12 bytes, and counter 4 bytes).
 
-      @raise Invalid_argument if invalid parameters are provided. Valid
-      parameters are: [key] must be 32 bytes and [nonce] 12 bytes for the
-      IETF mode (and counter fit into 32 bits), or [key] must be either 16
-      bytes or 32 bytes and [nonce] 8 bytes.
+      @raise Invalid_argument if invalid parameters are provided or the counter
+      wraps. Valid parameters are: [key] must be 32 bytes and [nonce] 12 bytes
+      for the IETF mode (and counter fit into 32 bits), or [key] must be either
+      16 bytes or 32 bytes and [nonce] 8 bytes.
   *)
 end
 

--- a/tests/test_cipher.ml
+++ b/tests/test_cipher.ml
@@ -922,6 +922,43 @@ let poly1305_rfc8439_2_5_2 _ =
   assert_oct_equal ~msg:"poly 1305 RFC8439 Section 2.5.2"
     (Poly1305.mac ~key data) output
 
+let counter_wraps =
+  let ctr _ =
+    let error = Invalid_argument "Mirage_crypto: CTR: counter wrapped" in
+    let aes_ctr = AES.CTR.ctr_of_octets (String.make AES.CTR.block_size '\xff')
+    and aes_key = AES.CTR.of_secret (String.make 16 '\x00')
+    and aes_zero = AES.CTR.ctr_of_octets (String.make AES.CTR.block_size '\x00')
+    and des_ctr = DES.CTR.ctr_of_octets (String.make DES.CTR.block_size '\xff')
+    and des_key = DES.CTR.of_secret (String.make 24 '\x00') in
+    assert_equal
+      (AES.CTR.ctr_of_octets (String.make 8 '\x00' ^ String.make 8 '\xff'))
+      (AES.CTR.add_ctr aes_zero (-1L));
+    assert_raises ~msg:"AES CTR add wraps" error
+      (fun () -> ignore (AES.CTR.add_ctr aes_ctr 1L));
+    ignore (AES.CTR.stream ~key:aes_key ~ctr:aes_ctr AES.CTR.block_size);
+    assert_raises ~msg:"AES CTR stream wraps" error
+      (fun () -> ignore (AES.CTR.stream ~key:aes_key ~ctr:aes_ctr 17));
+    ignore (DES.CTR.stream ~key:des_key ~ctr:des_ctr DES.CTR.block_size);
+    assert_raises ~msg:"DES CTR add wraps" error
+      (fun () -> ignore (DES.CTR.add_ctr des_ctr 1L))
+  and chacha _ =
+    let error = Invalid_argument "Mirage_crypto: Chacha20: counter wrapped" in
+    let key = Chacha20.of_secret (String.make 32 '\x00')
+    and block = String.make 64 '\x00'
+    and data = String.make 65 '\x00' in
+    ignore (Chacha20.crypt ~key ~nonce:(String.make 12 '\x00')
+      ~ctr:0xffffffffL block);
+    assert_raises ~msg:"ChaCha20 32-bit counter wraps" error
+      (fun () -> ignore (Chacha20.crypt ~key ~nonce:(String.make 12 '\x00')
+          ~ctr:0xffffffffL data));
+    ignore (Chacha20.crypt ~key ~nonce:(String.make 8 '\x00')
+      ~ctr:Int64.minus_one block);
+    assert_raises ~msg:"ChaCha20 64-bit counter wraps" error
+      (fun () -> ignore (Chacha20.crypt ~key ~nonce:(String.make 8 '\x00')
+          ~ctr:Int64.minus_one data))
+  in
+  [ test_case ctr ; test_case chacha ]
+
 let empty_cases _ =
   let plain = ""
   and cipher = ""
@@ -1054,6 +1091,7 @@ let suite = [
   "AES-GCM-REGRESSION" >::: gcm_regressions ;
   "Chacha20" >::: chacha20_cases ;
   "poly1305" >:: poly1305_rfc8439_2_5_2 ;
+  "counter wrap" >::: counter_wraps ;
   "empty" >:: empty_cases ;
   "AEAD-forged-tag" >::: aead_forged_tag ;
 ]

--- a/tests/test_random_runner.ml
+++ b/tests/test_random_runner.ml
@@ -57,14 +57,13 @@ let ctr_selftest (m : (module Block.CTR)) n =
     assert_oct_equal ~msg:"CTR chain" enc @@
       M.encrypt ~key ~ctr d1 ^ M.encrypt ~key ~ctr:(M.next_ctr ~ctr d1) d2
 
-let ctr_offsets (type c) ~zero (m : (module Block.CTR with type ctr = c)) n =
+let ctr_offsets (m : (module Block.CTR)) n =
   let module M = (val m) in
   "offsets" >:: fun _ ->
     let key = M.of_secret @@ Mirage_crypto_rng.generate M.key_sizes.(0) in
-    for i = 0 to n - 1 do
-      let ctr = match i with
-        | 0 -> M.add_ctr zero (-1L)
-        | _ -> Mirage_crypto_rng.generate M.block_size |> M.ctr_of_octets
+    for _i = 0 to n - 1 do
+      let ctr =
+        "\x00" ^ Mirage_crypto_rng.generate (M.block_size - 1) |> M.ctr_of_octets
       and gap = Randomconv.int ~bound:64 Mirage_crypto_rng.generate in
       let s1 = M.stream ~key ~ctr ((gap + 1) * M.block_size)
       and s2 = M.stream ~key ~ctr:(M.add_ctr ctr (Int64.of_int gap)) M.block_size in
@@ -95,12 +94,12 @@ let suite =
     "3DES-CBC" >::: [ cbc_selftest (module DES.CBC) 100 ] ;
 
     "3DES-CTR" >::: [ ctr_selftest (module DES.CTR) 100;
-                      ctr_offsets  (module DES.CTR) 100 ~zero:0L; ] ;
+                      ctr_offsets  (module DES.CTR) 100; ] ;
 
     "AES-ECB" >::: [ ecb_selftest (module AES.ECB) 100 ] ;
     "AES-CBC" >::: [ cbc_selftest (module AES.CBC) 100 ] ;
     "AES-CTR" >::: [ ctr_selftest (module AES.CTR) 100;
-                     ctr_offsets  (module AES.CTR) 100 ~zero:(0L, 0L) ] ;
+                     ctr_offsets  (module AES.CTR) 100 ] ;
 
   ]
 


### PR DESCRIPTION
Counter-based ciphers encrypt successive counter values to produce a keystream. If the counter wraps to zero, they can produce keystream that was already used under the same key.

Check the complete request before writing output. AES and DES CTR now reject requests that exhaust their 128-bit or 64-bit counters. ChaCha20 does the same for its 32-bit and 64-bit variants.

AES-GCM is slightly different: its 32-bit increment is defined to wrap. It therefore retains that behavior but rejects requests exceeding the specified 4,294,967,294-block limit.

The tests confirm that the final available block succeeds and the next block is rejected.