### PR TITLE
Use block limits for stream ciphers

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,8 +8,8 @@
 - mirage-crypto-rng-mkernel: seed Stdlib.Random once the RNG is seeded
   (#300 @hannesm)
 - mirage-crypto: CCM reject oversized messages (#304 @torinnd)
-- mirage-crypto: (CCM, ChaCha20, GCM) reject wrapping of stream cipher counters
-  (#305 @torinnd)
+- mirage-crypto: CCM, ChaCha20, and GCM enforce block-count limits
+  (#304 #305 @torinnd)
 - mirage-crypto-rng: avoid duplicate output after fork (#302 @torinnd)
 
 ## v2.4.0 (2026-08-17)

--- a/src/chacha20.ml
+++ b/src/chacha20.ml
@@ -20,12 +20,13 @@ let init ctr ~key ~nonce ~blocks =
   and inc64 b = set_ctr64 b (Int64.add (Bytes.get_int64_le b ctr_off) 1L)
   in
   let check_blocks max =
-    if Int64.of_int blocks > max then invalid_arg "Chacha20: too many blocks"
+    if Int64.unsigned_compare (Int64.of_int blocks) max > 0 then
+      invalid_arg "Chacha20: too many blocks"
   in
   let s, key, init_ctr, nonce_off, inc =
     match String.length key, String.length nonce, Int64.shift_right ctr 32 = 0L with
     | 32, 12, true ->
-      check_blocks 0xfffffffeL;
+      check_blocks 0x100000000L;
       let ctr = Int64.to_int32 ctr in
       "expand 32-byte k", key, (fun b -> set_ctr32 b ctr), 52, inc32
     | 32, 12, false ->
@@ -106,7 +107,18 @@ let mac_into ~key ~adata src ~src_off len dst ~dst_off =
                            len_buf, 0, String.length len_buf ]
     dst ~dst_off
 
+let check_aead_blocks nonce len =
+  let blocks = len // block in
+  match String.length nonce with
+  | 12 ->
+    if Int64.of_int blocks > 0xffffffffL then invalid_arg "Chacha20: too many blocks"
+  | 8 ->
+    if Int64.unsigned_compare (Int64.of_int blocks) Int64.minus_one > 0 then
+      invalid_arg "Chacha20: too many blocks"
+  | _ -> ()
+
 let unsafe_authenticate_encrypt_into ~key ~nonce ?(adata = "") src ~src_off dst ~dst_off ~tag_off len =
+  check_aead_blocks nonce len;
   let poly1305_key = generate_poly1305_key ~key ~nonce in
   crypt_into ~key ~nonce ~ctr:1L src ~src_off dst ~dst_off len;
   mac_into ~key:poly1305_key ~adata (Bytes.unsafe_to_string dst) ~src_off:dst_off len dst ~dst_off:tag_off
@@ -136,6 +148,7 @@ let authenticate_encrypt_tag ~key ~nonce ?adata data =
   String.sub r 0 (String.length data), String.sub r (String.length data) tag_size
 
 let unsafe_authenticate_decrypt_into ~key ~nonce ?(adata = "") src ~src_off ~tag_off dst ~dst_off len =
+  check_aead_blocks nonce len;
   let poly1305_key = generate_poly1305_key ~key ~nonce in
   let ctag = Bytes.create tag_size in
   mac_into ~key:poly1305_key ~adata src ~src_off len ctag ~dst_off:0;

--- a/src/chacha20.ml
+++ b/src/chacha20.ml
@@ -25,15 +25,17 @@ let init ctr ~key ~nonce ~blocks =
   let s, key, init_ctr, nonce_off, inc =
     match String.length key, String.length nonce, Int64.shift_right ctr 32 = 0L with
     | 32, 12, true ->
-      check_blocks 0x100000000L;
+      check_blocks 0xfffffffeL;
       let ctr = Int64.to_int32 ctr in
       "expand 32-byte k", key, (fun b -> set_ctr32 b ctr), 52, inc32
     | 32, 12, false ->
       invalid_arg "Counter too big for IETF mode (32 bit counter)"
     | 32, 8, _ ->
+      check_blocks Int64.minus_one;
       "expand 32-byte k", key, (fun b -> set_ctr64 b ctr), 56, inc64
     | 16, 8, _ ->
       let k = key ^ key in
+      check_blocks Int64.minus_one;
       "expand 16-byte k", k, (fun b -> set_ctr64 b ctr), 56, inc64
     | _ -> invalid_arg "Valid parameters are nonce 12 bytes and key 32 bytes \
                         (counter 32 bit), or nonce 8 byte and key 16 or 32 \
@@ -104,12 +106,7 @@ let mac_into ~key ~adata src ~src_off len dst ~dst_off =
                            len_buf, 0, String.length len_buf ]
     dst ~dst_off
 
-let check_aead_blocks nonce len =
-  if String.length nonce = 12 && Int64.of_int (len // block) > 0xffffffffL then
-    invalid_arg "Chacha20: too many blocks"
-
 let unsafe_authenticate_encrypt_into ~key ~nonce ?(adata = "") src ~src_off dst ~dst_off ~tag_off len =
-  check_aead_blocks nonce len;
   let poly1305_key = generate_poly1305_key ~key ~nonce in
   crypt_into ~key ~nonce ~ctr:1L src ~src_off dst ~dst_off len;
   mac_into ~key:poly1305_key ~adata (Bytes.unsafe_to_string dst) ~src_off:dst_off len dst ~dst_off:tag_off
@@ -139,7 +136,6 @@ let authenticate_encrypt_tag ~key ~nonce ?adata data =
   String.sub r 0 (String.length data), String.sub r (String.length data) tag_size
 
 let unsafe_authenticate_decrypt_into ~key ~nonce ?(adata = "") src ~src_off ~tag_off dst ~dst_off len =
-  check_aead_blocks nonce len;
   let poly1305_key = generate_poly1305_key ~key ~nonce in
   let ctag = Bytes.create tag_size in
   mac_into ~key:poly1305_key ~adata src ~src_off len ctag ~dst_off:0;

--- a/src/chacha20.ml
+++ b/src/chacha20.ml
@@ -19,24 +19,20 @@ let init ctr ~key ~nonce ~blocks =
   let inc32 b = set_ctr32 b (Int32.add (Bytes.get_int32_le b ctr_off) 1l)
   and inc64 b = set_ctr64 b (Int64.add (Bytes.get_int64_le b ctr_off) 1L)
   in
-  let check_counter max =
-    if blocks > 0
-       && Int64.unsigned_compare (Int64.of_int (blocks - 1)) (Int64.sub max ctr) > 0
-    then invalid_arg "Chacha20: counter wrapped"
+  let check_blocks max =
+    if Int64.of_int blocks > max then invalid_arg "Chacha20: too many blocks"
   in
   let s, key, init_ctr, nonce_off, inc =
     match String.length key, String.length nonce, Int64.shift_right ctr 32 = 0L with
     | 32, 12, true ->
-      check_counter 0xffffffffL;
+      check_blocks 0x100000000L;
       let ctr = Int64.to_int32 ctr in
       "expand 32-byte k", key, (fun b -> set_ctr32 b ctr), 52, inc32
     | 32, 12, false ->
       invalid_arg "Counter too big for IETF mode (32 bit counter)"
     | 32, 8, _ ->
-      check_counter Int64.minus_one;
       "expand 32-byte k", key, (fun b -> set_ctr64 b ctr), 56, inc64
     | 16, 8, _ ->
-      check_counter Int64.minus_one;
       let k = key ^ key in
       "expand 16-byte k", k, (fun b -> set_ctr64 b ctr), 56, inc64
     | _ -> invalid_arg "Valid parameters are nonce 12 bytes and key 32 bytes \
@@ -108,7 +104,12 @@ let mac_into ~key ~adata src ~src_off len dst ~dst_off =
                            len_buf, 0, String.length len_buf ]
     dst ~dst_off
 
+let check_aead_blocks nonce len =
+  if String.length nonce = 12 && Int64.of_int (len // block) > 0xffffffffL then
+    invalid_arg "Chacha20: too many blocks"
+
 let unsafe_authenticate_encrypt_into ~key ~nonce ?(adata = "") src ~src_off dst ~dst_off ~tag_off len =
+  check_aead_blocks nonce len;
   let poly1305_key = generate_poly1305_key ~key ~nonce in
   crypt_into ~key ~nonce ~ctr:1L src ~src_off dst ~dst_off len;
   mac_into ~key:poly1305_key ~adata (Bytes.unsafe_to_string dst) ~src_off:dst_off len dst ~dst_off:tag_off
@@ -138,6 +139,7 @@ let authenticate_encrypt_tag ~key ~nonce ?adata data =
   String.sub r 0 (String.length data), String.sub r (String.length data) tag_size
 
 let unsafe_authenticate_decrypt_into ~key ~nonce ?(adata = "") src ~src_off ~tag_off dst ~dst_off len =
+  check_aead_blocks nonce len;
   let poly1305_key = generate_poly1305_key ~key ~nonce in
   let ctag = Bytes.create tag_size in
   mac_into ~key:poly1305_key ~adata src ~src_off len ctag ~dst_off:0;

--- a/src/cipher_block.ml
+++ b/src/cipher_block.ml
@@ -105,16 +105,10 @@ module Block = struct
 end
 
 module Counters = struct
-  let wrapped () = invalid_arg "CTR: counter wrapped"
-
-  let check_count add ctr blocks =
-    if blocks > 0 then ignore (add ctr (Int64.of_int (blocks - 1)))
-
   module type S = sig
     type ctr
     val size : int
     val add  : ctr -> int64 -> ctr
-    val check : ctr -> int -> unit
     val of_octets : string -> ctr
     val unsafe_count_into : ctr -> bytes -> off:int -> blocks:int -> unit
   end
@@ -123,11 +117,7 @@ module Counters = struct
     type ctr = int64
     let size = 8
     let of_octets cs = String.get_int64_be cs 0
-    let add t n =
-      let t' = Int64.add t n in
-      if Int64.unsigned_compare t' t < 0 then wrapped ();
-      t'
-    let check = check_count add
+    let add = Int64.add
     let unsafe_count_into t buf ~off ~blocks =
       let ctr = Bytes.create 8 in
       Bytes.set_int64_be ctr 0 t;
@@ -143,9 +133,7 @@ module Counters = struct
     let add (w1, w0) n =
       let w0' = Int64.add w0 n in
       let carry = Int64.unsigned_compare w0' w0 < 0 in
-      if carry && w1 = -1L then wrapped ();
       ((if carry then Int64.succ w1 else w1), w0')
-    let check = check_count add
     let unsafe_count_into (w1, w0) buf ~off ~blocks =
       let ctr = Bytes.create 16 in
       Bytes.set_int64_be ctr 0 w1; Bytes.set_int64_be ctr 8 w0;
@@ -157,8 +145,6 @@ module Counters = struct
     let add (w1, w0) n =
       let hi = 0xffffffff00000000L and lo = 0x00000000ffffffffL in
       (w1, Int64.(logor (logand hi w0) (add n w0 |> logand lo)))
-    let check _ blocks =
-      if Int64.of_int blocks > 0xfffffffeL then wrapped ()
     let unsafe_count_into (w1, w0) buf ~off ~blocks =
       let ctr = Bytes.create 16 in
       Bytes.set_int64_be ctr 0 w1; Bytes.set_int64_be ctr 8 w0;
@@ -305,10 +291,9 @@ module Modes = struct
 
     let unsafe_stream_into ~key ~ctr buf ~off len =
       let blocks = imax 0 len / block_size in
-      let slack = imax 0 len mod block_size in
-      Ctr.check ctr (blocks + if slack = 0 then 0 else 1);
       Ctr.unsafe_count_into ctr buf ~off ~blocks ;
       Core.encrypt ~key ~blocks (Bytes.unsafe_to_string buf) off buf off ;
+      let slack = imax 0 len mod block_size in
       if slack <> 0 then begin
         let buf' = Bytes.create block_size in
         let ctr = Ctr.add ctr (Int64.of_int blocks) in
@@ -420,7 +405,12 @@ module Modes = struct
               (pack64s (bits64 adata) (Int64.of_int (len * 8)), 0, 16)))
         ~src_off:0 dst ~dst_off:tag_off tag_size
 
+    let check_blocks len =
+      if Int64.of_int (len // block_size) > 0xfffffffeL then
+        invalid_arg "GCM: too many blocks"
+
     let unsafe_authenticate_encrypt_into ~key:{ key; hkey } ~nonce ?adata src ~src_off dst ~dst_off ~tag_off len =
+      check_blocks len;
       let ctr = counter ~hkey nonce in
       CTR.(unsafe_encrypt_into ~key ~ctr:(add_ctr ctr 1L) src ~src_off dst ~dst_off len);
       unsafe_tag_into ~key ~hkey ~ctr ?adata (Bytes.unsafe_to_string dst) ~off:dst_off ~len dst ~tag_off
@@ -443,6 +433,7 @@ module Modes = struct
       String.sub r (String.length data) tag_size
 
     let unsafe_authenticate_decrypt_into ~key:{ key; hkey } ~nonce ?adata src ~src_off ~tag_off dst ~dst_off len =
+      check_blocks len;
       let ctr = counter ~hkey nonce in
       let ctag = Bytes.create tag_size in
       unsafe_tag_into ~key ~hkey ~ctr ?adata src ~off:src_off ~len ctag ~tag_off:0;

--- a/src/cipher_block.ml
+++ b/src/cipher_block.ml
@@ -408,6 +408,7 @@ module Modes = struct
     let check_blocks len =
       if Int64.of_int (len // block_size) > 0xfffffffeL then
         invalid_arg "GCM: too many blocks"
+    [@@inline always]
 
     let unsafe_authenticate_encrypt_into ~key:{ key; hkey } ~nonce ?adata src ~src_off dst ~dst_off ~tag_off len =
       check_blocks len;

--- a/src/cipher_block.ml
+++ b/src/cipher_block.ml
@@ -105,10 +105,15 @@ module Block = struct
 end
 
 module Counters = struct
+  let check_block_count max blocks =
+    if Int64.unsigned_compare (Int64.of_int blocks) max > 0 then
+      invalid_arg "CTR: too many blocks"
+
   module type S = sig
     type ctr
     val size : int
     val add  : ctr -> int64 -> ctr
+    val check_blocks : int -> unit
     val of_octets : string -> ctr
     val unsafe_count_into : ctr -> bytes -> off:int -> blocks:int -> unit
   end
@@ -118,6 +123,7 @@ module Counters = struct
     let size = 8
     let of_octets cs = String.get_int64_be cs 0
     let add = Int64.add
+    let check_blocks = check_block_count Int64.minus_one
     let unsafe_count_into t buf ~off ~blocks =
       let ctr = Bytes.create 8 in
       Bytes.set_int64_be ctr 0 t;
@@ -134,6 +140,7 @@ module Counters = struct
       let w0' = Int64.add w0 n in
       let carry = Int64.unsigned_compare w0' w0 < 0 in
       ((if carry then Int64.succ w1 else w1), w0')
+    let check_blocks _ = ()
     let unsafe_count_into (w1, w0) buf ~off ~blocks =
       let ctr = Bytes.create 16 in
       Bytes.set_int64_be ctr 0 w1; Bytes.set_int64_be ctr 8 w0;
@@ -145,6 +152,7 @@ module Counters = struct
     let add (w1, w0) n =
       let hi = 0xffffffff00000000L and lo = 0x00000000ffffffffL in
       (w1, Int64.(logor (logand hi w0) (add n w0 |> logand lo)))
+    let check_blocks = check_block_count 0xfffffffeL
     let unsafe_count_into (w1, w0) buf ~off ~blocks =
       let ctr = Bytes.create 16 in
       Bytes.set_int64_be ctr 0 w1; Bytes.set_int64_be ctr 8 w0;
@@ -291,9 +299,10 @@ module Modes = struct
 
     let unsafe_stream_into ~key ~ctr buf ~off len =
       let blocks = imax 0 len / block_size in
+      let slack = imax 0 len mod block_size in
+      Ctr.check_blocks (blocks + if slack = 0 then 0 else 1);
       Ctr.unsafe_count_into ctr buf ~off ~blocks ;
       Core.encrypt ~key ~blocks (Bytes.unsafe_to_string buf) off buf off ;
-      let slack = imax 0 len mod block_size in
       if slack <> 0 then begin
         let buf' = Bytes.create block_size in
         let ctr = Ctr.add ctr (Int64.of_int blocks) in
@@ -405,9 +414,7 @@ module Modes = struct
               (pack64s (bits64 adata) (Int64.of_int (len * 8)), 0, 16)))
         ~src_off:0 dst ~dst_off:tag_off tag_size
 
-    let check_blocks len =
-      if Int64.of_int (len // block_size) > 0xfffffffeL then
-        invalid_arg "GCM: too many blocks"
+    let check_blocks len = Counters.C128be32.check_blocks (len // block_size)
     [@@inline always]
 
     let unsafe_authenticate_encrypt_into ~key:{ key; hkey } ~nonce ?adata src ~src_off dst ~dst_off ~tag_off len =

--- a/src/mirage_crypto.mli
+++ b/src/mirage_crypto.mli
@@ -539,8 +539,9 @@ val accelerated : [`XOR | `AES | `GHASH] list
 
 (** The ChaCha20 cipher proposed by D.J. Bernstein.
 
-    In IETF AEAD mode, messages may span at most [2^32 - 1] blocks because
-    counter 0 is used to derive the Poly1305 key. *)
+    In AEAD mode, messages may span at most [2^32 - 1] blocks with a 12-byte
+    nonce and [2^64 - 1] blocks with an 8-byte nonce because counter 0 is used
+    to derive the Poly1305 key. *)
 module Chacha20 : sig
   include AEAD
 
@@ -554,9 +555,10 @@ module Chacha20 : sig
       specification (where nonce is 12 bytes, and counter 4 bytes).
 
       @raise Invalid_argument if invalid parameters are provided or [data] spans
-      more than [2^32] blocks in IETF mode. Valid parameters are: [key] must be
-      32 bytes and [nonce] 12 bytes for the IETF mode (and counter fit into 32
-      bits), or [key] must be either 16 bytes or 32 bytes and [nonce] 8 bytes.
+      more than [2^32] blocks in IETF mode or [2^64 - 1] blocks in the original
+      mode. Valid parameters are: [key] must be 32 bytes and [nonce] 12 bytes
+      for the IETF mode (and counter fit into 32 bits), or [key] must be either
+      16 bytes or 32 bytes and [nonce] 8 bytes.
   *)
 end
 

--- a/src/mirage_crypto.mli
+++ b/src/mirage_crypto.mli
@@ -409,9 +409,7 @@ end
     type ctr
 
     val add_ctr : ctr -> int64 -> ctr
-    (** [add_ctr ctr n] adds the unsigned 64-bit value [n] to [ctr].
-
-        @raise Invalid_argument if the counter wraps. *)
+    (** [add_ctr ctr n] adds the unsigned 64-bit value [n] to [ctr]. *)
 
     val next_ctr : ?off:int -> string -> ctr:ctr -> ctr
     (** [next_ctr ~off msg ~ctr] is the state of the counter after encrypting or
@@ -426,7 +424,7 @@ end
 {[encrypt ~ctr msg1 || encrypt ~ctr:(next_ctr ~ctr msg1) msg2
   == encrypt ~ctr (msg1 || msg2)]}
 
-        @raise Invalid_argument if the counter wraps. *)
+    *)
 
     val ctr_of_octets : string -> ctr
     (** [ctr_of_octets buf] converts the value of [buf] into a counter. *)
@@ -445,9 +443,7 @@ end
   == stream ~key ~ctr (k * block_size + x)]}
 
         In other words, it is possible to restart a keystream at [block_size]
-        boundaries by manipulating the counter.
-
-        @raise Invalid_argument if the counter wraps. *)
+        boundaries by manipulating the counter. *)
 
     val encrypt : key:key -> ctr:ctr -> string -> string
     (** [encrypt ~key ~ctr msg] is
@@ -460,7 +456,7 @@ end
     (** [stream_into ~key ~ctr dst ~off len] is the raw key stream put into
         [dst] starting at [off].
 
-        @raise Invalid_argument if [Bytes.length dst - off < len] or the counter wraps. *)
+        @raise Invalid_argument if [Bytes.length dst - off < len]. *)
 
     val encrypt_into : key:key -> ctr:ctr -> string -> src_off:int ->
       bytes -> dst_off:int -> int -> unit
@@ -469,8 +465,7 @@ end
         [src_off].
 
         @raise Invalid_argument if [dst_off < 0 || Bytes.length dst - dst_off < len].
-        @raise Invalid_argument if [src_off < 0 || String.length src - src_off < len].
-        @raise Invalid_argument if the counter wraps. *)
+        @raise Invalid_argument if [src_off < 0 || String.length src - src_off < len]. *)
 
     val decrypt_into : key:key -> ctr:ctr -> string -> src_off:int ->
       bytes -> dst_off:int -> int -> unit
@@ -499,7 +494,7 @@ end
     (**/**)
   end
 
-  (** {e Galois/Counter Mode}. *)
+  (** {e Galois/Counter Mode}. Messages may span at most [2^32 - 2] blocks. *)
   module type GCM = sig
 
     include AEAD
@@ -542,7 +537,10 @@ val accelerated : [`XOR | `AES | `GHASH] list
 (** Operations using non-portable, hardware-dependent implementation in
       this build of the library. *)
 
-(** The ChaCha20 cipher proposed by D.J. Bernstein. *)
+(** The ChaCha20 cipher proposed by D.J. Bernstein.
+
+    In IETF AEAD mode, messages may span at most [2^32 - 1] blocks because
+    counter 0 is used to derive the Poly1305 key. *)
 module Chacha20 : sig
   include AEAD
 
@@ -555,10 +553,10 @@ module Chacha20 : sig
       the counter is 8 byte, same as the nonce) and the IETF RFC 8439
       specification (where nonce is 12 bytes, and counter 4 bytes).
 
-      @raise Invalid_argument if invalid parameters are provided or the counter
-      wraps. Valid parameters are: [key] must be 32 bytes and [nonce] 12 bytes
-      for the IETF mode (and counter fit into 32 bits), or [key] must be either
-      16 bytes or 32 bytes and [nonce] 8 bytes.
+      @raise Invalid_argument if invalid parameters are provided or [data] spans
+      more than [2^32] blocks in IETF mode. Valid parameters are: [key] must be
+      32 bytes and [nonce] 12 bytes for the IETF mode (and counter fit into 32
+      bits), or [key] must be either 16 bytes or 32 bytes and [nonce] 8 bytes.
   *)
 end
 

--- a/tests/test_cipher.ml
+++ b/tests/test_cipher.ml
@@ -949,42 +949,14 @@ let poly1305_rfc8439_2_5_2 _ =
   assert_oct_equal ~msg:"poly 1305 RFC8439 Section 2.5.2"
     (Poly1305.mac ~key data) output
 
-let counter_wraps =
-  let ctr _ =
-    let error = Invalid_argument "Mirage_crypto: CTR: counter wrapped" in
-    let aes_ctr = AES.CTR.ctr_of_octets (String.make AES.CTR.block_size '\xff')
-    and aes_key = AES.CTR.of_secret (String.make 16 '\x00')
-    and aes_zero = AES.CTR.ctr_of_octets (String.make AES.CTR.block_size '\x00')
-    and des_ctr = DES.CTR.ctr_of_octets (String.make DES.CTR.block_size '\xff')
-    and des_key = DES.CTR.of_secret (String.make 24 '\x00') in
-    assert_equal
-      (AES.CTR.ctr_of_octets (String.make 8 '\x00' ^ String.make 8 '\xff'))
-      (AES.CTR.add_ctr aes_zero (-1L));
-    assert_raises ~msg:"AES CTR add wraps" error
-      (fun () -> ignore (AES.CTR.add_ctr aes_ctr 1L));
-    ignore (AES.CTR.stream ~key:aes_key ~ctr:aes_ctr AES.CTR.block_size);
-    assert_raises ~msg:"AES CTR stream wraps" error
-      (fun () -> ignore (AES.CTR.stream ~key:aes_key ~ctr:aes_ctr 17));
-    ignore (DES.CTR.stream ~key:des_key ~ctr:des_ctr DES.CTR.block_size);
-    assert_raises ~msg:"DES CTR add wraps" error
-      (fun () -> ignore (DES.CTR.add_ctr des_ctr 1L))
-  and chacha _ =
-    let error = Invalid_argument "Mirage_crypto: Chacha20: counter wrapped" in
-    let key = Chacha20.of_secret (String.make 32 '\x00')
-    and block = String.make 64 '\x00'
-    and data = String.make 65 '\x00' in
-    ignore (Chacha20.crypt ~key ~nonce:(String.make 12 '\x00')
-      ~ctr:0xffffffffL block);
-    assert_raises ~msg:"ChaCha20 32-bit counter wraps" error
-      (fun () -> ignore (Chacha20.crypt ~key ~nonce:(String.make 12 '\x00')
-          ~ctr:0xffffffffL data));
-    ignore (Chacha20.crypt ~key ~nonce:(String.make 8 '\x00')
-      ~ctr:Int64.minus_one block);
-    assert_raises ~msg:"ChaCha20 64-bit counter wraps" error
-      (fun () -> ignore (Chacha20.crypt ~key ~nonce:(String.make 8 '\x00')
-          ~ctr:Int64.minus_one data))
-  in
-  [ test_case ctr ; test_case chacha ]
+let chacha20_counter_rollover _ =
+  let key = Chacha20.of_secret (String.make 32 '\x00')
+  and nonce = String.make 12 '\x00'
+  and data = String.make 65 '\x00' in
+  let first = Chacha20.crypt ~key ~nonce ~ctr:0xffffffffL (String.sub data 0 64) in
+  let last = Chacha20.crypt ~key ~nonce ~ctr:0L (String.sub data 64 1) in
+  assert_oct_equal ~msg:"Chacha20 counter rollover"
+    (Chacha20.crypt ~key ~nonce ~ctr:0xffffffffL data) (first ^ last)
 
 let empty_cases _ =
   let plain = ""
@@ -1118,7 +1090,7 @@ let suite = [
   "AES-GCM-REGRESSION" >::: gcm_regressions ;
   "Chacha20" >::: chacha20_cases ;
   "poly1305" >:: poly1305_rfc8439_2_5_2 ;
-  "counter wrap" >::: counter_wraps ;
+  "Chacha20 counter rollover" >:: chacha20_counter_rollover ;
   "empty" >:: empty_cases ;
   "AEAD-forged-tag" >::: aead_forged_tag ;
 ]

--- a/tests/test_random_runner.ml
+++ b/tests/test_random_runner.ml
@@ -57,13 +57,14 @@ let ctr_selftest (m : (module Block.CTR)) n =
     assert_oct_equal ~msg:"CTR chain" enc @@
       M.encrypt ~key ~ctr d1 ^ M.encrypt ~key ~ctr:(M.next_ctr ~ctr d1) d2
 
-let ctr_offsets (m : (module Block.CTR)) n =
+let ctr_offsets (type c) ~zero (m : (module Block.CTR with type ctr = c)) n =
   let module M = (val m) in
   "offsets" >:: fun _ ->
     let key = M.of_secret @@ Mirage_crypto_rng.generate M.key_sizes.(0) in
-    for _i = 0 to n - 1 do
-      let ctr =
-        "\x00" ^ Mirage_crypto_rng.generate (M.block_size - 1) |> M.ctr_of_octets
+    for i = 0 to n - 1 do
+      let ctr = match i with
+        | 0 -> M.add_ctr zero (-1L)
+        | _ -> Mirage_crypto_rng.generate M.block_size |> M.ctr_of_octets
       and gap = Randomconv.int ~bound:64 Mirage_crypto_rng.generate in
       let s1 = M.stream ~key ~ctr ((gap + 1) * M.block_size)
       and s2 = M.stream ~key ~ctr:(M.add_ctr ctr (Int64.of_int gap)) M.block_size in
@@ -108,12 +109,12 @@ let suite =
     "3DES-CBC" >::: [ cbc_selftest (module DES.CBC) 100 ] ;
 
     "3DES-CTR" >::: [ ctr_selftest (module DES.CTR) 100;
-                      ctr_offsets  (module DES.CTR) 100; ] ;
+                      ctr_offsets  (module DES.CTR) 100 ~zero:0L; ] ;
 
     "AES-ECB" >::: [ ecb_selftest (module AES.ECB) 100 ] ;
     "AES-CBC" >::: [ cbc_selftest (module AES.CBC) 100 ] ;
     "AES-CTR" >::: [ ctr_selftest (module AES.CTR) 100;
-                     ctr_offsets  (module AES.CTR) 100 ] ;
+                     ctr_offsets  (module AES.CTR) 100 ~zero:(0L, 0L) ] ;
 
   ]
 


### PR DESCRIPTION
PR #305 rejected numeric counter rollover, which was a bit too conservative. Raw CTR may start at a protocol-derived value, so crossing zero is valid provided no counter repeats.

We should restore modular AES/DES CTR and raw ChaCha20 behavior, and continue enforcing the mode-level limits: $2^{32}-2$ blocks for GCM, $2^{32}$ blocks for raw IETF ChaCha20, and $2^{32}-1$ blocks for ChaCha20-Poly1305.